### PR TITLE
feat: Implement Refresh Token

### DIFF
--- a/src/main/java/com/diary/shared_diary/auth/JwtUtil.java
+++ b/src/main/java/com/diary/shared_diary/auth/JwtUtil.java
@@ -15,17 +15,26 @@ public class JwtUtil {
     @Value("${jwt.secret}")
     private String secret;
 
-    private static final long EXPIRATION_MS = 1000 * 60 * 60 * 24; // 24시간
+    private static final long ACCESS_TOKEN_EXPIRATION_MS = 1000 * 60 * 60 * 24; // 24시간
+    private static final long REFRESH_TOKEN_EXPIRATION_MS = 1000L * 60 * 60 * 24 * 30; // 30일
 
     private Key getSigningKey() {
         return Keys.hmacShaKeyFor(Decoders.BASE64.decode(secret));
     }
 
-    public String generateToken(String email) {
+    public String generateAccessToken(String email) {
+        return generateToken(email, ACCESS_TOKEN_EXPIRATION_MS);
+    }
+
+    public String generateRefreshToken(String email) {
+        return generateToken(email, REFRESH_TOKEN_EXPIRATION_MS);
+    }
+
+    private String generateToken(String email, long expirationMs) {
         return Jwts.builder()
                 .setSubject(email)
                 .setIssuedAt(new Date())
-                .setExpiration(new Date(System.currentTimeMillis() + EXPIRATION_MS))
+                .setExpiration(new Date(System.currentTimeMillis() + expirationMs))
                 .signWith(getSigningKey(), SignatureAlgorithm.HS256)
                 .compact();
     }

--- a/src/main/java/com/diary/shared_diary/config/JwtAuthenticationFilter.java
+++ b/src/main/java/com/diary/shared_diary/config/JwtAuthenticationFilter.java
@@ -6,19 +6,21 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 
+@Slf4j
+@Component
+@RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtUtil jwtUtil;
-
-    public JwtAuthenticationFilter(JwtUtil jwtUtil) {
-        this.jwtUtil = jwtUtil;
-    }
 
     @Override
     protected void doFilterInternal(HttpServletRequest request,
@@ -29,13 +31,17 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         String authHeader = request.getHeader("Authorization");
         if (authHeader != null && authHeader.startsWith("Bearer ")) {
             String token = authHeader.substring(7);
-            String email = jwtUtil.validateAndGetEmail(token); // 유효성 검사 및 이메일 추출
-            if (email != null) {
-                CustomUserDetails userDetails = new CustomUserDetails(email);
-                UsernamePasswordAuthenticationToken authentication =
-                        new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+            try {
+                String email = jwtUtil.validateAndGetEmail(token); // 유효성 검사 및 이메일 추출
+                if (email != null) {
+                    CustomUserDetails userDetails = new CustomUserDetails(email);
+                    UsernamePasswordAuthenticationToken authentication =
+                            new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
 
-                SecurityContextHolder.getContext().setAuthentication(authentication);
+                    SecurityContextHolder.getContext().setAuthentication(authentication);
+                }
+            } catch (Exception e) {
+                log.error("JWT Token validation error", e);
             }
 
         }

--- a/src/main/java/com/diary/shared_diary/config/SecurityConfig.java
+++ b/src/main/java/com/diary/shared_diary/config/SecurityConfig.java
@@ -19,6 +19,7 @@ public class SecurityConfig {
 
     private final JwtUtil jwtUtil;
     private final OAuth2Properties oAuth2Properties;
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -32,13 +33,13 @@ public class SecurityConfig {
                         .disable()
                 )
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/login/**", "/oauth2/**", "/login/oauth2/**", "/h2-console/**", "/dev/**").permitAll()
+                        .requestMatchers("/login/**", "/oauth2/**", "/login/oauth2/**", "/h2-console/**", "/dev/**", "/api/auth/refresh", "/api/auth/token").permitAll()
                         .requestMatchers("/api/groups/**", "/api/diaries/**").authenticated()
                 )
                 .oauth2Login(oauth2 -> oauth2
                         .defaultSuccessUrl("/login/success", true)
                 )
-                .addFilterBefore(new JwtAuthenticationFilter(jwtUtil), UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
                 .exceptionHandling(e -> e
                         .authenticationEntryPoint((request, response, authException) -> {
                             response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "인증이 필요합니다.");

--- a/src/main/java/com/diary/shared_diary/controller/AuthController.java
+++ b/src/main/java/com/diary/shared_diary/controller/AuthController.java
@@ -72,22 +72,6 @@ public class AuthController {
 
         return ResponseEntity.ok(new LoginSuccessResponseDto(accessToken, refreshToken));
     }
-//
-//    @PostMapping("/api/auth/refresh")
-//    public ResponseEntity<LoginSuccessResponseDto> refreshToken(@RequestBody Map<String, String> request) {
-//        String refreshToken = request.get("refreshToken");
-//        String email = jwtUtil.validateAndGetEmail(refreshToken);
-//        User user = userRepository.findByRefreshToken(refreshToken)
-//                .orElseThrow(() -> new IllegalArgumentException("Invalid refresh token"));
-//
-//        if (!email.equals(user.getEmail())) {
-//            throw new IllegalArgumentException("Invalid refresh token");
-//        }
-//
-//        String newAccessToken = jwtUtil.generateAccessToken(email);
-//        return ResponseEntity.ok(new LoginSuccessResponseDto(newAccessToken, refreshToken));
-//    }
-
 
     @PostMapping("/api/auth/refresh")
     public ResponseEntity<LoginSuccessResponseDto> refreshToken(@RequestBody Map<String, String> request) {

--- a/src/main/java/com/diary/shared_diary/controller/AuthController.java
+++ b/src/main/java/com/diary/shared_diary/controller/AuthController.java
@@ -3,17 +3,19 @@ package com.diary.shared_diary.controller;
 import com.diary.shared_diary.auth.JwtUtil;
 import com.diary.shared_diary.config.OAuth2Properties;
 import com.diary.shared_diary.domain.User;
+import com.diary.shared_diary.dto.auth.LoginSuccessResponseDto;
 import com.diary.shared_diary.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.oauth2.core.user.OAuth2User;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.time.LocalDateTime;
 import java.util.Map;
+import java.util.UUID;
 
 @RestController
 @RequiredArgsConstructor
@@ -24,8 +26,7 @@ public class AuthController {
     private final OAuth2Properties oAuth2Properties;
 
     @GetMapping("/login/success")
-    public void loginSuccess(@AuthenticationPrincipal OAuth2User oauth2User,
-                             HttpServletResponse response) throws IOException {
+    public void loginSuccess(@AuthenticationPrincipal OAuth2User oauth2User, HttpServletResponse response) throws IOException {
         if (oauth2User == null) {
             response.sendError(401, "인증 실패");
             return;
@@ -42,9 +43,81 @@ public class AuthController {
                         .createdAt(LocalDateTime.now())
                         .build()));
 
-        String token = jwtUtil.generateToken(user.getEmail());
-        String redirectUri = oAuth2Properties.getRedirectUri();
+        String authorizationCode = UUID.randomUUID().toString();
+        user.setAuthorizationCode(authorizationCode);
+        user.setAuthorizationCodeExpiresAt(LocalDateTime.now().plusMinutes(1)); // 1분 후 만료
+        userRepository.save(user);
 
-        response.sendRedirect(redirectUri + "?token=" + token);
+        String redirectUri = oAuth2Properties.getRedirectUri();
+        response.sendRedirect(redirectUri + "?code=" + authorizationCode);
+    }
+
+    @PostMapping("/api/auth/token")
+    public ResponseEntity<LoginSuccessResponseDto> exchangeCodeForTokens(@RequestBody Map<String, String> request) {
+        String authorizationCode = request.get("code");
+        User user = userRepository.findByAuthorizationCode(authorizationCode)
+                .orElseThrow(() -> new IllegalArgumentException("Invalid authorization code"));
+
+        if (user.getAuthorizationCodeExpiresAt().isBefore(LocalDateTime.now())) {
+            throw new IllegalArgumentException("Authorization code has expired");
+        }
+
+        user.setAuthorizationCode(null);
+        user.setAuthorizationCodeExpiresAt(null);
+
+        String accessToken = jwtUtil.generateAccessToken(user.getEmail());
+        String refreshToken = jwtUtil.generateRefreshToken(user.getEmail());
+        user.setRefreshToken(refreshToken);
+        userRepository.save(user);
+
+        return ResponseEntity.ok(new LoginSuccessResponseDto(accessToken, refreshToken));
+    }
+//
+//    @PostMapping("/api/auth/refresh")
+//    public ResponseEntity<LoginSuccessResponseDto> refreshToken(@RequestBody Map<String, String> request) {
+//        String refreshToken = request.get("refreshToken");
+//        String email = jwtUtil.validateAndGetEmail(refreshToken);
+//        User user = userRepository.findByRefreshToken(refreshToken)
+//                .orElseThrow(() -> new IllegalArgumentException("Invalid refresh token"));
+//
+//        if (!email.equals(user.getEmail())) {
+//            throw new IllegalArgumentException("Invalid refresh token");
+//        }
+//
+//        String newAccessToken = jwtUtil.generateAccessToken(email);
+//        return ResponseEntity.ok(new LoginSuccessResponseDto(newAccessToken, refreshToken));
+//    }
+
+
+    @PostMapping("/api/auth/refresh")
+    public ResponseEntity<LoginSuccessResponseDto> refreshToken(@RequestBody Map<String, String> request) {
+        String oldRefreshToken = request.get("refreshToken");
+
+        // 1. JWT 유효성 검사 및 사용자 이메일 추출
+        String email = jwtUtil.validateAndGetEmail(oldRefreshToken);
+
+        // 2. DB에서 리프레시 토큰 일치 여부 확인 (토큰 소유자 확인)
+        User user = userRepository.findByRefreshToken(oldRefreshToken)
+                .orElseThrow(() -> new IllegalArgumentException("Invalid or Expired refresh token"));
+
+        if (!email.equals(user.getEmail())) {
+            // 토큰 내부의 이메일과 DB에 저장된 사용자의 이메일이 다르면 비정상 접근
+            throw new IllegalArgumentException("Mismatched refresh token owner");
+        }
+
+        // --- 리프레시 토큰 로테이션 (RTR) 적용 시작 ---
+
+        // 3. 새로운 액세스 토큰과 리프레시 토큰 발급
+        String newAccessToken = jwtUtil.generateAccessToken(email);
+        String newRefreshToken = jwtUtil.generateRefreshToken(email);
+
+        // 4. DB에 새로운 리프레시 토큰 저장 (기존 토큰 폐기 효과)
+        user.setRefreshToken(newRefreshToken);
+        userRepository.save(user);
+
+        // 5. 새로운 액세스 토큰과 새로운 리프레시 토큰을 클라이언트에 전달
+        return ResponseEntity.ok(new LoginSuccessResponseDto(newAccessToken, newRefreshToken));
+
+        // --- RTR 적용 완료 ---
     }
 }

--- a/src/main/java/com/diary/shared_diary/controller/DevAuthController.java
+++ b/src/main/java/com/diary/shared_diary/controller/DevAuthController.java
@@ -30,11 +30,15 @@ public class DevAuthController {
 
         return userRepository.findByEmail(email)
                 .map(user -> {
-                    String token = jwtUtil.generateToken(email);
+                    String accessToken = jwtUtil.generateAccessToken(email);
+                    String refreshToken = jwtUtil.generateRefreshToken(email);
+                    user.setRefreshToken(refreshToken);
+                    userRepository.save(user);
                     return ResponseEntity.ok(new DevLoginResponseDto(
                             user.getEmail(),
                             user.getUsername(),
-                            token
+                            accessToken,
+                            refreshToken
                     ));
                 })
                 .orElseGet(() -> ResponseEntity.status(HttpStatus.NOT_FOUND).body(null));

--- a/src/main/java/com/diary/shared_diary/controller/DiaryController.java
+++ b/src/main/java/com/diary/shared_diary/controller/DiaryController.java
@@ -8,7 +8,6 @@ import com.diary.shared_diary.service.DiaryService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequestMapping("/api/groups/{groupId}/diaries")

--- a/src/main/java/com/diary/shared_diary/domain/User.java
+++ b/src/main/java/com/diary/shared_diary/domain/User.java
@@ -23,6 +23,11 @@ public class User {
     private String username;
     private String email;
 
+    private String refreshToken;
+
+    private String authorizationCode;
+    private LocalDateTime authorizationCodeExpiresAt;
+
     private LocalDateTime createdAt;
 
     @OneToMany(mappedBy = "author")

--- a/src/main/java/com/diary/shared_diary/dto/auth/LoginSuccessResponseDto.java
+++ b/src/main/java/com/diary/shared_diary/dto/auth/LoginSuccessResponseDto.java
@@ -1,7 +1,13 @@
 package com.diary.shared_diary.dto.auth;
 
-public record LoginSuccessResponseDto(
-        String email,
-        String username,
-        String token
-) {}
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class LoginSuccessResponseDto {
+    private String accessToken;
+    private String refreshToken;
+}

--- a/src/main/java/com/diary/shared_diary/dto/dev/DevLoginResponseDto.java
+++ b/src/main/java/com/diary/shared_diary/dto/dev/DevLoginResponseDto.java
@@ -4,6 +4,7 @@ package com.diary.shared_diary.dto.dev;
 public record DevLoginResponseDto (
         String email,
         String username,
-        String token
+        String accessToken,
+        String refreshToken
 ) {}
 

--- a/src/main/java/com/diary/shared_diary/repository/UserRepository.java
+++ b/src/main/java/com/diary/shared_diary/repository/UserRepository.java
@@ -8,6 +8,8 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByEmail(String email);
     Optional<User> findByEmail(String email);
+    Optional<User> findByRefreshToken(String refreshToken);
+    Optional<User> findByAuthorizationCode(String authorizationCode);
     default User getByEmail(String email) {
         return findByEmail(email)
                 .orElseThrow(() -> new RuntimeException("User not found"));


### PR DESCRIPTION
**Changes:**

*   **Authorization:**
    *   Implemented refresh token functionality for more secure and persistent authentication.
    *   Introduced a token refresh endpoint (`/api/auth/refresh`).
    *   Enhanced `JwtUtil` to generate both access and refresh tokens with different expiration times.
    *   Modified the login process to issue both access and refresh tokens upon successful authentication.
    *   The `User` entity has been updated to store the refresh token.
    *   The login success response DTO (`LoginSuccessResponseDto`) now includes both `accessToken` and `refreshToken`.
    *   The development login endpoint (`/dev/login`) has also been updated to return both token types.
*   **Security:**
    *   Updated `SecurityConfig` to permit access to the new refresh token endpoint.
    *   Added error handling to `JwtAuthenticationFilter` to gracefully manage token validation errors.
*   **Code Refinements:**
    *   Adopted `@RequiredArgsConstructor` in `JwtAuthenticationFilter` for cleaner dependency injection.
    *   Removed an unused import (`MultipartFile`) from `DiaryController`.

This pull request introduces a refresh token mechanism to improve the application's authentication system.