### PR TITLE
Feat: Refresh Token 기능 추가

### DIFF
--- a/src/main/java/com/diary/shared_diary/controller/AuthController.java
+++ b/src/main/java/com/diary/shared_diary/controller/AuthController.java
@@ -5,8 +5,10 @@ import com.diary.shared_diary.config.OAuth2Properties;
 import com.diary.shared_diary.domain.User;
 import com.diary.shared_diary.dto.auth.LoginSuccessResponseDto;
 import com.diary.shared_diary.repository.UserRepository;
+import io.jsonwebtoken.ExpiredJwtException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.web.bind.annotation.*;
@@ -85,37 +87,42 @@ public class AuthController {
     }
 
     @PostMapping("/api/auth/refresh")
-    public ResponseEntity<LoginSuccessResponseDto> refreshToken(@RequestBody Map<String, String> request) {
+    public ResponseEntity<?> refreshToken(@RequestBody Map<String, String> request) {
         String oldRefreshToken = request.get("refreshToken");
         log.info("[AUTH-TOKEN-REFRESH] Attempting to refresh token.");
 
-        // 1. JWT 유효성 검사 및 사용자 이메일 추출
-        String email = jwtUtil.validateAndGetEmail(oldRefreshToken);
+        try {
+            // 1. JWT 유효성 검사 및 사용자 이메일 추출
+            String email = jwtUtil.validateAndGetEmail(oldRefreshToken);
 
-        // 2. DB에서 리프레시 토큰 일치 여부 확인 (토큰 소유자 확인)
-        User user = userRepository.findByRefreshToken(oldRefreshToken)
-                .orElseThrow(() -> new IllegalArgumentException("Invalid or Expired refresh token"));
+            // 2. DB에서 리프레시 토큰 일치 여부 확인 (토큰 소유자 확인)
+            User user = userRepository.findByRefreshToken(oldRefreshToken)
+                    .orElseThrow(() -> new IllegalArgumentException("Invalid or Expired refresh token"));
 
-        if (!email.equals(user.getEmail())) {
-            // 토큰 내부의 이메일과 DB에 저장된 사용자의 이메일이 다르면 비정상 접근
-            log.warn("[AUTH-TOKEN-REFRESH] Mismatched refresh token owner. Token email: {}, User email: {}", email, user.getEmail());
-            throw new IllegalArgumentException("Mismatched refresh token owner");
+            if (!email.equals(user.getEmail())) {
+                // 토큰 내부의 이메일과 DB에 저장된 사용자의 이메일이 다르면 비정상 접근
+                log.warn("[AUTH-TOKEN-REFRESH] Mismatched refresh token owner. Token email: {}, User email: {}", email, user.getEmail());
+                throw new IllegalArgumentException("Mismatched refresh token owner");
+            }
+
+            // --- 리프레시 토큰 로테이션 (RTR) 적용 시작 ---
+
+            // 3. 새로운 액세스 토큰과 리프레시 토큰 발급
+            String newAccessToken = jwtUtil.generateAccessToken(email);
+            String newRefreshToken = jwtUtil.generateRefreshToken(email);
+
+            // 4. DB에 새로운 리프레시 토큰 저장 (기존 토큰 폐기 효과)
+            user.setRefreshToken(newRefreshToken);
+            userRepository.save(user);
+            log.info("[AUTH-TOKEN-REFRESH] Successfully refreshed token for user: {}", email);
+
+            // 5. 새로운 액세스 토큰과 새로운 리프레시 토큰을 클라이언트에 전달
+            return ResponseEntity.ok(new LoginSuccessResponseDto(newAccessToken, newRefreshToken));
+
+            // --- RTR 적용 완료 ---
+        } catch (ExpiredJwtException e) {
+            log.warn("[AUTH-TOKEN-REFRESH] Refresh token has expired.");
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Refresh token has expired.");
         }
-
-        // --- 리프레시 토큰 로테이션 (RTR) 적용 시작 ---
-
-        // 3. 새로운 액세스 토큰과 리프레시 토큰 발급
-        String newAccessToken = jwtUtil.generateAccessToken(email);
-        String newRefreshToken = jwtUtil.generateRefreshToken(email);
-
-        // 4. DB에 새로운 리프레시 토큰 저장 (기존 토큰 폐기 효과)
-        user.setRefreshToken(newRefreshToken);
-        userRepository.save(user);
-        log.info("[AUTH-TOKEN-REFRESH] Successfully refreshed token for user: {}", email);
-
-        // 5. 새로운 액세스 토큰과 새로운 리프레시 토큰을 클라이언트에 전달
-        return ResponseEntity.ok(new LoginSuccessResponseDto(newAccessToken, newRefreshToken));
-
-        // --- RTR 적용 완료 ---
     }
 }

--- a/src/main/java/com/diary/shared_diary/controller/AuthController.java
+++ b/src/main/java/com/diary/shared_diary/controller/AuthController.java
@@ -6,6 +6,7 @@ import com.diary.shared_diary.domain.User;
 import com.diary.shared_diary.dto.auth.LoginSuccessResponseDto;
 import com.diary.shared_diary.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.web.bind.annotation.*;
@@ -17,6 +18,7 @@ import java.time.LocalDateTime;
 import java.util.Map;
 import java.util.UUID;
 
+@Slf4j
 @RestController
 @RequiredArgsConstructor
 public class AuthController {
@@ -28,6 +30,7 @@ public class AuthController {
     @GetMapping("/login/success")
     public void loginSuccess(@AuthenticationPrincipal OAuth2User oauth2User, HttpServletResponse response) throws IOException {
         if (oauth2User == null) {
+            log.warn("[AUTH-LOGIN-FAIL] Authentication failed, OAuth2User is null.");
             response.sendError(401, "인증 실패");
             return;
         }
@@ -35,18 +38,23 @@ public class AuthController {
         Map<String, Object> kakaoAccount = (Map<String, Object>) oauth2User.getAttribute("kakao_account");
         String email = (String) kakaoAccount.get("email");
         String nickname = (String) ((Map<String, Object>) kakaoAccount.get("profile")).get("nickname");
+        log.info("[AUTH-LOGIN-SUCCESS] User logged in successfully: {}", email);
 
         User user = userRepository.findByEmail(email)
-                .orElseGet(() -> userRepository.save(User.builder()
+                .orElseGet(() -> {
+                    log.info("New user detected, creating a new user account for: {}", email);
+                    return userRepository.save(User.builder()
                         .email(email)
                         .username(nickname)
                         .createdAt(LocalDateTime.now())
-                        .build()));
+                        .build());
+                });
 
         String authorizationCode = UUID.randomUUID().toString();
         user.setAuthorizationCode(authorizationCode);
         user.setAuthorizationCodeExpiresAt(LocalDateTime.now().plusMinutes(1)); // 1분 후 만료
         userRepository.save(user);
+        log.info("Generated authorization code for user: {}", email);
 
         String redirectUri = oAuth2Properties.getRedirectUri();
         response.sendRedirect(redirectUri + "?code=" + authorizationCode);
@@ -55,10 +63,12 @@ public class AuthController {
     @PostMapping("/api/auth/token")
     public ResponseEntity<LoginSuccessResponseDto> exchangeCodeForTokens(@RequestBody Map<String, String> request) {
         String authorizationCode = request.get("code");
+        log.info("[AUTH-TOKEN-EXCHANGE] Attempting to exchange authorization code for tokens.");
         User user = userRepository.findByAuthorizationCode(authorizationCode)
                 .orElseThrow(() -> new IllegalArgumentException("Invalid authorization code"));
 
         if (user.getAuthorizationCodeExpiresAt().isBefore(LocalDateTime.now())) {
+            log.warn("[AUTH-TOKEN-EXCHANGE] Authorization code has expired for user: {}", user.getEmail());
             throw new IllegalArgumentException("Authorization code has expired");
         }
 
@@ -69,6 +79,7 @@ public class AuthController {
         String refreshToken = jwtUtil.generateRefreshToken(user.getEmail());
         user.setRefreshToken(refreshToken);
         userRepository.save(user);
+        log.info("[AUTH-TOKEN-EXCHANGE] Successfully exchanged code for tokens for user: {}", user.getEmail());
 
         return ResponseEntity.ok(new LoginSuccessResponseDto(accessToken, refreshToken));
     }
@@ -76,6 +87,7 @@ public class AuthController {
     @PostMapping("/api/auth/refresh")
     public ResponseEntity<LoginSuccessResponseDto> refreshToken(@RequestBody Map<String, String> request) {
         String oldRefreshToken = request.get("refreshToken");
+        log.info("[AUTH-TOKEN-REFRESH] Attempting to refresh token.");
 
         // 1. JWT 유효성 검사 및 사용자 이메일 추출
         String email = jwtUtil.validateAndGetEmail(oldRefreshToken);
@@ -86,6 +98,7 @@ public class AuthController {
 
         if (!email.equals(user.getEmail())) {
             // 토큰 내부의 이메일과 DB에 저장된 사용자의 이메일이 다르면 비정상 접근
+            log.warn("[AUTH-TOKEN-REFRESH] Mismatched refresh token owner. Token email: {}, User email: {}", email, user.getEmail());
             throw new IllegalArgumentException("Mismatched refresh token owner");
         }
 
@@ -98,6 +111,7 @@ public class AuthController {
         // 4. DB에 새로운 리프레시 토큰 저장 (기존 토큰 폐기 효과)
         user.setRefreshToken(newRefreshToken);
         userRepository.save(user);
+        log.info("[AUTH-TOKEN-REFRESH] Successfully refreshed token for user: {}", email);
 
         // 5. 새로운 액세스 토큰과 새로운 리프레시 토큰을 클라이언트에 전달
         return ResponseEntity.ok(new LoginSuccessResponseDto(newAccessToken, newRefreshToken));

--- a/src/main/java/com/diary/shared_diary/controller/CommentController.java
+++ b/src/main/java/com/diary/shared_diary/controller/CommentController.java
@@ -4,11 +4,13 @@ import com.diary.shared_diary.auth.CustomUserDetails;
 import com.diary.shared_diary.dto.comment.CommentRequestDto;
 import com.diary.shared_diary.dto.comment.CommentResponseDto;
 import com.diary.shared_diary.service.CommentService;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
+@Slf4j
 @RestController
 @RequestMapping("/api/diaries/{diaryId}/comments")
 public class CommentController {
@@ -22,6 +24,7 @@ public class CommentController {
     @GetMapping
     public List<CommentResponseDto> getComments(@PathVariable Long diaryId,
                                                 @AuthenticationPrincipal CustomUserDetails userDetails) {
+        log.info("[COMMENT-GET] Request user: {}, diary: {}", userDetails.getUsername(), diaryId);
         return commentService.getComments(diaryId, userDetails.getUsername());
     }
 
@@ -29,6 +32,7 @@ public class CommentController {
     public CommentResponseDto createComment(@PathVariable Long diaryId,
                                             @AuthenticationPrincipal CustomUserDetails userDetails,
                                             @RequestBody CommentRequestDto dto) {
+        log.info("[COMMENT-CREATE] Request user: {}, diary: {}", userDetails.getUsername(), diaryId);
         return commentService.createComment(diaryId, userDetails.getUsername(), dto);
     }
 }

--- a/src/main/java/com/diary/shared_diary/controller/DiaryController.java
+++ b/src/main/java/com/diary/shared_diary/controller/DiaryController.java
@@ -5,10 +5,12 @@ import com.diary.shared_diary.dto.diary.DiaryDetailResponseDto;
 import com.diary.shared_diary.dto.diary.DiaryRequestDto;
 import com.diary.shared_diary.dto.diary.DiaryResponseDto;
 import com.diary.shared_diary.service.DiaryService;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+@Slf4j
 @RestController
 @RequestMapping("/api/groups/{groupId}/diaries")
 public class DiaryController {
@@ -25,6 +27,7 @@ public class DiaryController {
             @ModelAttribute DiaryRequestDto dto,
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
+        log.info("[DIARY-CREATE] Request user: {}, group: {}", userDetails.getUsername(), groupId);
         DiaryResponseDto result = diaryService.createDiary(groupId, userDetails.getUsername(), dto, dto.getImage());
         return ResponseEntity.ok(result);
     }
@@ -35,6 +38,7 @@ public class DiaryController {
             @PathVariable Long diaryId,
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
+        log.info("[DIARY-GET] Request user: {}, diary: {}", userDetails.getUsername(), diaryId);
         String email = userDetails.getUsername();
         return diaryService.getDiaryDetail(diaryId, email);
     }

--- a/src/main/java/com/diary/shared_diary/controller/GroupController.java
+++ b/src/main/java/com/diary/shared_diary/controller/GroupController.java
@@ -6,11 +6,13 @@ import com.diary.shared_diary.repository.GroupRepository;
 import com.diary.shared_diary.service.GroupService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
+@Slf4j
 @RestController
 @RequestMapping("/api/groups")
 @RequiredArgsConstructor
@@ -23,12 +25,14 @@ public class GroupController {
     @GetMapping("/user")
     public List<GroupResponseDto> getUserGroups(@AuthenticationPrincipal CustomUserDetails userDetails) {
         String email = userDetails.getUsername(); // 또는 userDetails.getEmail();
+        log.info("[GROUP-GET-USER] Request user: {}", email);
         return groupService.getGroupsByUserEmail(email);
     }
 
 
     @PostMapping("/join")
     public void joinGroup(@RequestBody @Valid JoinGroupRequestDto dto, @AuthenticationPrincipal CustomUserDetails userDetails) {
+        log.info("[GROUP-JOIN] Request user: {}, group code: {}", userDetails.getUsername(), dto.code());
         groupService.joinGroupByCode(dto.code(), userDetails.getUsername());
     }
 
@@ -36,6 +40,7 @@ public class GroupController {
     @GetMapping("/{groupId}")
     public GroupDetailResponseDto getGroupDetail(@PathVariable Long groupId, @AuthenticationPrincipal CustomUserDetails userDetails) {
         String email = userDetails.getUsername();
+        log.info("[GROUP-GET-DETAIL] Request user: {}, group: {}", email, groupId);
         return groupService.getGroupDetail(groupId, email);
     }
 
@@ -46,6 +51,7 @@ public class GroupController {
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
         String email = userDetails.getUsername();
+        log.info("[GROUP-CREATE] Request user: {}", email);
         return groupService.createGroup(email, dto);
     }
 
@@ -54,6 +60,7 @@ public class GroupController {
             @PathVariable Long groupId,
             @RequestBody GroupMemberAddRequestDto dto
     ) {
+        log.info("[GROUP-ADD-MEMBER] Add members to group: {}", groupId);
         groupService.addMembers(groupId, dto.userIds());
     }
 }

--- a/src/main/java/com/diary/shared_diary/controller/UserController.java
+++ b/src/main/java/com/diary/shared_diary/controller/UserController.java
@@ -3,10 +3,12 @@ package com.diary.shared_diary.controller;
 import com.diary.shared_diary.dto.user.UserRequestDto;
 import com.diary.shared_diary.dto.user.UserResponseDto;
 import com.diary.shared_diary.service.UserService;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
+@Slf4j
 @RestController
 @RequestMapping("/api/users")
 public class UserController {
@@ -19,18 +21,21 @@ public class UserController {
 
     @PostMapping
     public UserResponseDto createUser(@RequestBody UserRequestDto dto) {
+        log.info("[USER-CREATE] Request to create user: {}", dto.email());
         return userService.createUser(dto);
     }
 
 
     @GetMapping
     public List<UserResponseDto> getUsers() {
+        log.info("[USER-GET-ALL] Request to get all users.");
         return userService.getAllUsers();
     }
 
 
     @GetMapping("/exists")
     public boolean checkEmail(@RequestParam String email) {
+        log.info("[USER-CHECK-EMAIL] Request to check email: {}", email);
         return userService.isEmailExists(email);
     }
 }

--- a/src/main/java/com/diary/shared_diary/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/diary/shared_diary/exception/GlobalExceptionHandler.java
@@ -1,24 +1,63 @@
 package com.diary.shared_diary.exception;
 
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.*;
 
 @Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
-    @ExceptionHandler(RuntimeException.class)
-    public ResponseEntity<String> handleRuntime(RuntimeException e) {
-        log.error("RuntimeException: ", e);
-        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("서버 에러: " + e.getMessage());
+    @ExceptionHandler(NotFoundException.class)
+    public ResponseEntity<String> handleNotFound(NotFoundException e) {
+        log.warn("NotFoundException: {}", e.getMessage());
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
+    }
+
+    @ExceptionHandler(IllegalStateException.class)
+    public ResponseEntity<String> handleIllegalState(IllegalStateException e) {
+        log.warn("IllegalStateException: {}", e.getMessage());
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(e.getMessage());
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<String> handleValidation(MethodArgumentNotValidException e) {
+        String message = e.getBindingResult().getAllErrors().get(0).getDefaultMessage();
+        log.warn("Validation Error: {}", message);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("유효성 검사 실패: " + message);
+    }
+
+    @ExceptionHandler(DataIntegrityViolationException.class)
+    public ResponseEntity<String> handleDataIntegrity(DataIntegrityViolationException e) {
+        log.error("Data Integrity Violation: ", e);
+        return ResponseEntity.status(HttpStatus.CONFLICT).body("데이터 처리 중 충돌이 발생했습니다.");
     }
 
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<String> handleIllegalArg(IllegalArgumentException e) {
         log.warn("IllegalArgumentException: {}", e.getMessage());
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("잘못된 요청: " + e.getMessage());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getMessage());
     }
 
+    @ExceptionHandler(AccessDeniedException.class)
+    public ResponseEntity<String> handleAccessDenied(AccessDeniedException e) {
+        log.warn("Access Denied: {}", e.getMessage());
+        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(e.getMessage());
+    }
+
+    @ExceptionHandler(InvalidTokenException.class)
+    public ResponseEntity<String> handleInvalidToken(InvalidTokenException e) {
+        log.warn("Invalid Token Attempt: {}", e.getMessage());
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(e.getMessage());
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<String> handleAll(Exception e) {
+        log.error("Unhandled Exception: ", e);
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("알 수 없는 서버 에러가 발생했습니다.");
+    }
 }

--- a/src/main/java/com/diary/shared_diary/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/diary/shared_diary/exception/GlobalExceptionHandler.java
@@ -1,19 +1,23 @@
 package com.diary.shared_diary.exception;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+@Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
     @ExceptionHandler(RuntimeException.class)
     public ResponseEntity<String> handleRuntime(RuntimeException e) {
+        log.error("RuntimeException: ", e);
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("서버 에러: " + e.getMessage());
     }
 
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<String> handleIllegalArg(IllegalArgumentException e) {
+        log.warn("IllegalArgumentException: {}", e.getMessage());
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("잘못된 요청: " + e.getMessage());
     }
 

--- a/src/main/java/com/diary/shared_diary/exception/InvalidTokenException.java
+++ b/src/main/java/com/diary/shared_diary/exception/InvalidTokenException.java
@@ -1,0 +1,7 @@
+package com.diary.shared_diary.exception;
+
+public class InvalidTokenException extends RuntimeException {
+    public InvalidTokenException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/diary/shared_diary/exception/NotFoundException.java
+++ b/src/main/java/com/diary/shared_diary/exception/NotFoundException.java
@@ -1,0 +1,11 @@
+package com.diary.shared_diary.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.NOT_FOUND)
+public class NotFoundException extends RuntimeException {
+    public NotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/diary/shared_diary/service/CommentService.java
+++ b/src/main/java/com/diary/shared_diary/service/CommentService.java
@@ -9,12 +9,14 @@ import com.diary.shared_diary.dto.comment.CommentResponseDto;
 import com.diary.shared_diary.repository.CommentRepository;
 import com.diary.shared_diary.repository.DiaryRepository;
 import com.diary.shared_diary.repository.UserRepository;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
+@Slf4j
 @Service
 public class CommentService {
 
@@ -31,6 +33,7 @@ public class CommentService {
     }
 
     public List<CommentResponseDto> getComments(Long diaryId, String email) {
+        log.info("Fetching comments for diaryId: {}, user: {}", diaryId, email);
         Diary diary = diaryRepository.findById(diaryId)
                 .orElseThrow(() -> new RuntimeException("일기를 찾을 수 없습니다."));
         User user = userRepository.findByEmail(email)
@@ -38,15 +41,18 @@ public class CommentService {
 
         Group group = diary.getGroup();
         if (!group.getMembers().contains(user)) {
+            log.warn("User {} is not a member of group {}. Access denied for diary {}.", email, diary.getGroup().getId(), diaryId);
             throw new RuntimeException("댓글을 볼 수 있는 권한이 없습니다.");
         }
 
+        log.info("Successfully fetched comments for diaryId: {}", diaryId);
         return commentRepository.findByDiaryOrderByCreatedAtAsc(diary).stream()
                 .map(CommentResponseDto::new)
                 .toList();
     }
 
     public CommentResponseDto createComment(Long diaryId, String email, CommentRequestDto dto) {
+        log.info("Start creating comment for user: {}, diary: {}", email, diaryId);
         Diary diary = diaryRepository.findById(diaryId)
                 .orElseThrow(() -> new RuntimeException("일기를 찾을 수 없습니다."));
         User user = userRepository.findByEmail(email)
@@ -54,6 +60,7 @@ public class CommentService {
 
         Group group = diary.getGroup();
         if (!group.getMembers().contains(user)) {
+            log.warn("User {} is not a member of group {}. Access denied for diary {}.", email, diary.getGroup().getId(), diaryId);
             throw new RuntimeException("해당 그룹 멤버만 댓글을 달 수 있습니다.");
         }
 
@@ -78,7 +85,8 @@ public class CommentService {
                 .parent(parent)
                 .build();
 
-        commentRepository.save(comment);
+        Comment saved = commentRepository.save(comment);
+        log.info("Comment created with id: {}", saved.getId());
         return new CommentResponseDto(comment);
     }
 }

--- a/src/main/java/com/diary/shared_diary/service/DiaryService.java
+++ b/src/main/java/com/diary/shared_diary/service/DiaryService.java
@@ -10,11 +10,13 @@ import com.diary.shared_diary.repository.DiaryRepository;
 import com.diary.shared_diary.repository.GroupRepository;
 import com.diary.shared_diary.repository.UserRepository;
 import com.diary.shared_diary.util.S3Uploader;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDateTime;
 
+@Slf4j
 @Service
 public class DiaryService {
 
@@ -31,18 +33,21 @@ public class DiaryService {
     }
 
     public DiaryResponseDto createDiary(Long groupId, String email, DiaryRequestDto dto, MultipartFile image) {
+        log.info("Start creating diary for user: {}, group: {}", email, groupId);
         User author = userRepository.findByEmail(email)
                 .orElseThrow(() -> new RuntimeException("User not found"));
         Group group = groupRepository.findById(groupId)
                 .orElseThrow(() -> new RuntimeException("Group not found"));
 
         if (!group.getMembers().contains(author)) {
+            log.warn("User {} is not a member of group {}. Access denied.", email, groupId);
             throw new RuntimeException("그룹에 속한 사용자만 작성할 수 있습니다.");
         }
 
         String imagePath = null;
         if (image != null && !image.isEmpty()) {
             imagePath = s3Uploader.upload(image, "diary"); // S3 Key 저장
+            log.info("Image uploaded to S3 with path: {}", imagePath);
         }
 
         Diary diary = Diary.builder()
@@ -55,12 +60,14 @@ public class DiaryService {
                 .build();
 
         Diary saved = diaryRepository.save(diary);
+        log.info("Diary created with id: {}", saved.getId());
         return new DiaryResponseDto(saved, s3Uploader);
     }
 
 
 
     public DiaryDetailResponseDto getDiaryDetail(Long diaryId, String email) {
+        log.info("Fetching diary detail for diaryId: {}, user: {}", diaryId, email);
         Diary diary = diaryRepository.findById(diaryId)
                 .orElseThrow(() -> new RuntimeException("Diary not found"));
 
@@ -69,9 +76,11 @@ public class DiaryService {
 
         // 권한 체크: 그룹 멤버만 조회 가능
         if (!diary.getGroup().getMembers().contains(user)) {
+            log.warn("User {} is not a member of group {}. Access denied for diary {}.", email, diary.getGroup().getId(), diaryId);
             throw new RuntimeException("해당 그룹에 속한 사용자만 조회할 수 있습니다.");
         }
 
+        log.info("Successfully fetched diary detail for diaryId: {}", diaryId);
         return new DiaryDetailResponseDto(diary, s3Uploader);
     }
 

--- a/src/main/java/com/diary/shared_diary/service/GroupService.java
+++ b/src/main/java/com/diary/shared_diary/service/GroupService.java
@@ -11,6 +11,7 @@ import com.diary.shared_diary.repository.GroupRepository;
 import com.diary.shared_diary.repository.UserRepository;
 import com.diary.shared_diary.util.CodeGenerator;
 import com.diary.shared_diary.util.S3Uploader;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
@@ -18,6 +19,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+@Slf4j
 @Service
 public class GroupService {
 
@@ -34,29 +36,34 @@ public class GroupService {
     }
 
     public List<GroupResponseDto> getGroupsByUserEmail(String email) {
+        log.info("Fetching groups for user: {}", email);
         User user = userRepository.findByEmail(email)
                 .orElseThrow(() -> new RuntimeException("User not found"));
 
         List<Group> groups = groupRepository.findAllByMembersContains(user);
-
+        log.info("Found {} groups for user: {}", groups.size(), email);
         return groups.stream()
                 .map(group -> new GroupResponseDto(group.getId(), group.getName(), group.getCode()))
                 .toList();
     }
 
     public GroupDetailResponseDto getGroupDetail(Long groupId, String email) {
+        log.info("Fetching group detail for groupId: {}, user: {}", groupId, email);
         Group group = groupRepository.getById(groupId);
         User user = userRepository.getByEmail(email);
 
         if (!group.getMembers().contains(user)) {
+            log.warn("User {} is not a member of group {}. Access denied.", email, groupId);
             throw new RuntimeException("해당 그룹에 접근할 권한이 없습니다.");
         }
         List<Diary> diaries = diaryRepository.findByGroupOrderByCreatedAtDesc(group);
 
+        log.info("Successfully fetched group detail for groupId: {}", groupId);
         return new GroupDetailResponseDto(group, diaries, s3Uploader);
     }
 
     public GroupResponseDto createGroup(String userEmail, GroupRequestDto dto) {
+        log.info("Creating group for user: {}", userEmail);
         User creator = userRepository.findByEmail(userEmail)
                 .orElseThrow(() -> new RuntimeException("User not found"));
 
@@ -65,6 +72,7 @@ public class GroupService {
         do {
             code = CodeGenerator.generateGroupCode();
         } while (groupRepository.findByCode(code).isPresent());
+        log.info("Generated unique group code: {}", code);
 
         Group group = Group.builder()
                 .name(dto.name())
@@ -74,23 +82,29 @@ public class GroupService {
                 .build();
 
         Group saved = groupRepository.save(group);
+        log.info("Group created with id: {}", saved.getId());
         return new GroupResponseDto(saved.getId(), saved.getName(), code);
     }
 
 
     public void joinGroupByCode(String code, String email) {
+        log.info("User {} attempts to join group with code: {}", email, code);
         Group group = groupRepository.getByCode(code);
         User user = userRepository.getByEmail(email);
 
         if (!group.getMembers().contains(user)) {
             group.addMember(user);
             groupRepository.save(group);
+            log.info("User {} successfully joined group with code: {}", email, code);
+        } else {
+            log.info("User {} is already a member of group with code: {}", email, code);
         }
     }
 
 
 
     public void addMembers(Long groupId, List<Long> userIds) {
+        log.info("Adding members to group: {}", groupId);
         Group group = groupRepository.findById(groupId)
                 .orElseThrow(() -> new RuntimeException("Group not found"));
 
@@ -101,6 +115,7 @@ public class GroupService {
         }
 
         groupRepository.save(group);
+        log.info("Successfully added {} members to group: {}", usersToAdd.size(), groupId);
     }
 
 }

--- a/src/main/java/com/diary/shared_diary/service/UserService.java
+++ b/src/main/java/com/diary/shared_diary/service/UserService.java
@@ -4,11 +4,13 @@ import com.diary.shared_diary.domain.User;
 import com.diary.shared_diary.dto.user.UserRequestDto;
 import com.diary.shared_diary.dto.user.UserResponseDto;
 import com.diary.shared_diary.repository.UserRepository;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
+@Slf4j
 @Service
 public class UserService {
 
@@ -19,6 +21,7 @@ public class UserService {
     }
 
     public UserResponseDto createUser(UserRequestDto dto) {
+        log.info("Creating user with email: {}", dto.email());
         User user = User.builder()
                 .username(dto.username())
                 .email(dto.email())
@@ -26,21 +29,28 @@ public class UserService {
                 .build();
 
         User saved = userRepository.save(user);
+        log.info("User created with id: {}", saved.getId());
         return new UserResponseDto(saved.getId(), saved.getUsername(), saved.getEmail());
     }
 
     public List<UserResponseDto> getAllUsers() {
-        return userRepository.findAll().stream()
+        log.info("Fetching all users.");
+        List<UserResponseDto> users = userRepository.findAll().stream()
                 .map(user -> new UserResponseDto(
                         user.getId(),
                         user.getUsername(),
                         user.getEmail()
                 ))
                 .toList();
+        log.info("Found {} users.", users.size());
+        return users;
     }
 
 
     public boolean isEmailExists(String email) {
-        return userRepository.existsByEmail(email);
+        log.info("Checking if email exists: {}", email);
+        boolean exists = userRepository.existsByEmail(email);
+        log.info("Email {} exists: {}", email, exists);
+        return exists;
     }
 }


### PR DESCRIPTION
## 변경 사항

* **Refresh Token 구현**: Refresh Token을 도입하여 사용자 인증을 유지하고, Refresh Token Rotation(RTR)을 적용하여 보안을 강화했습니다.
* **인증 흐름 변경**: 기존에 바로 토큰을 반환하는 대신, Authorization Code를 발급하고, 이를 토큰으로 교환하는 로직을 추가했습니다.
* **로깅 추가**: 주요 컨트롤러와 서비스에 SLF4J 로깅을 추가하여 디버깅 및 모니터링을 용이하게 했습니다.
* **Refresh Token 만료 처리**: Refresh Token이 만료되었을 때, 401 Unauthorized 에러를 반환하도록 처리했습니다.
