### PR TITLE
feat: 일기 암호화 기능 추가 및 리팩토링

### DIFF
--- a/src/main/java/com/diary/shared_diary/config/SecurityConfig.java
+++ b/src/main/java/com/diary/shared_diary/config/SecurityConfig.java
@@ -34,7 +34,7 @@ public class SecurityConfig {
                 )
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/login/**", "/oauth2/**", "/login/oauth2/**", "/h2-console/**", "/dev/**", "/api/auth/refresh", "/api/auth/token").permitAll()
-                        .requestMatchers("/api/groups/**", "/api/diaries/**").authenticated()
+                        .requestMatchers("/api/groups/**", "/api/diaries/**", "/api/users/me", "/api/users/public-key").authenticated()
                 )
                 .oauth2Login(oauth2 -> oauth2
                         .defaultSuccessUrl("/login/success", true)

--- a/src/main/java/com/diary/shared_diary/controller/AuthController.java
+++ b/src/main/java/com/diary/shared_diary/controller/AuthController.java
@@ -105,7 +105,7 @@ public class AuthController {
             if (!email.equals(user.getEmail())) {
                 // 토큰 내부의 이메일과 DB에 저장된 사용자의 이메일이 다르면 비정상 접근
                 log.warn("[AUTH-TOKEN-REFRESH] Mismatched refresh token owner. Token email: {}, User email: {}", email, user.getEmail());
-                throw new InvalidTokenException(("Mismatched refresh token owner"));
+                throw new InvalidTokenException("Mismatched refresh token owner");
             }
 
             // --- 리프레시 토큰 로테이션 (RTR) 적용 시작 ---

--- a/src/main/java/com/diary/shared_diary/controller/AuthController.java
+++ b/src/main/java/com/diary/shared_diary/controller/AuthController.java
@@ -4,6 +4,8 @@ import com.diary.shared_diary.auth.JwtUtil;
 import com.diary.shared_diary.config.OAuth2Properties;
 import com.diary.shared_diary.domain.User;
 import com.diary.shared_diary.dto.auth.LoginSuccessResponseDto;
+import com.diary.shared_diary.dto.user.UserResponseDto;
+import com.diary.shared_diary.exception.InvalidTokenException;
 import com.diary.shared_diary.repository.UserRepository;
 import io.jsonwebtoken.ExpiredJwtException;
 import lombok.RequiredArgsConstructor;
@@ -82,8 +84,9 @@ public class AuthController {
         user.setRefreshToken(refreshToken);
         userRepository.save(user);
         log.info("[AUTH-TOKEN-EXCHANGE] Successfully exchanged code for tokens for user: {}", user.getEmail());
+        UserResponseDto userResponse = UserResponseDto.from(user);
 
-        return ResponseEntity.ok(new LoginSuccessResponseDto(accessToken, refreshToken));
+        return ResponseEntity.ok(new LoginSuccessResponseDto(accessToken, refreshToken, userResponse));
     }
 
     @PostMapping("/api/auth/refresh")
@@ -97,12 +100,12 @@ public class AuthController {
 
             // 2. DB에서 리프레시 토큰 일치 여부 확인 (토큰 소유자 확인)
             User user = userRepository.findByRefreshToken(oldRefreshToken)
-                    .orElseThrow(() -> new IllegalArgumentException("Invalid or Expired refresh token"));
+                    .orElseThrow(() -> new InvalidTokenException("Invalid or Expired refresh token"));
 
             if (!email.equals(user.getEmail())) {
                 // 토큰 내부의 이메일과 DB에 저장된 사용자의 이메일이 다르면 비정상 접근
                 log.warn("[AUTH-TOKEN-REFRESH] Mismatched refresh token owner. Token email: {}, User email: {}", email, user.getEmail());
-                throw new IllegalArgumentException("Mismatched refresh token owner");
+                throw new InvalidTokenException(("Mismatched refresh token owner"));
             }
 
             // --- 리프레시 토큰 로테이션 (RTR) 적용 시작 ---
@@ -116,8 +119,10 @@ public class AuthController {
             userRepository.save(user);
             log.info("[AUTH-TOKEN-REFRESH] Successfully refreshed token for user: {}", email);
 
+            UserResponseDto userResponse = UserResponseDto.from(user);
+
             // 5. 새로운 액세스 토큰과 새로운 리프레시 토큰을 클라이언트에 전달
-            return ResponseEntity.ok(new LoginSuccessResponseDto(newAccessToken, newRefreshToken));
+            return ResponseEntity.ok(new LoginSuccessResponseDto(newAccessToken, newRefreshToken, userResponse));
 
             // --- RTR 적용 완료 ---
         } catch (ExpiredJwtException e) {

--- a/src/main/java/com/diary/shared_diary/controller/UserController.java
+++ b/src/main/java/com/diary/shared_diary/controller/UserController.java
@@ -32,11 +32,11 @@ public class UserController {
     }
 
 
-    @GetMapping
-    public List<UserResponseDto> getUsers() {
-        log.info("[USER-GET-ALL] Request to get all users.");
-        return userService.getAllUsers();
-    }
+//    @GetMapping
+//    public List<UserResponseDto> getUsers() {
+//        log.info("[USER-GET-ALL] Request to get all users.");
+//        return userService.getAllUsers();
+//    }
 
     @GetMapping("/me")
     public ResponseEntity<UserResponseDto> getCurrentUser(@AuthenticationPrincipal CustomUserDetails userDetails) {

--- a/src/main/java/com/diary/shared_diary/controller/UserController.java
+++ b/src/main/java/com/diary/shared_diary/controller/UserController.java
@@ -1,9 +1,15 @@
 package com.diary.shared_diary.controller;
 
+import com.diary.shared_diary.auth.CustomUserDetails;
+import com.diary.shared_diary.domain.User;
+import com.diary.shared_diary.dto.user.PublicKeyRequestDto;
 import com.diary.shared_diary.dto.user.UserRequestDto;
 import com.diary.shared_diary.dto.user.UserResponseDto;
 import com.diary.shared_diary.service.UserService;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -32,10 +38,37 @@ public class UserController {
         return userService.getAllUsers();
     }
 
+    @GetMapping("/me")
+    public ResponseEntity<UserResponseDto> getCurrentUser(@AuthenticationPrincipal CustomUserDetails userDetails) {
+        if (userDetails == null) {
+            throw new AccessDeniedException("로그인이 필요한 서비스입니다.");
+        }
+
+        UserResponseDto userResponse = userService.getUserResponseByEmail(userDetails.getUsername());
+
+        return ResponseEntity.ok(userResponse);
+    }
 
     @GetMapping("/exists")
     public boolean checkEmail(@RequestParam String email) {
         log.info("[USER-CHECK-EMAIL] Request to check email: {}", email);
         return userService.isEmailExists(email);
+    }
+
+    @PostMapping("/public-key")
+    public ResponseEntity<Void> updatePublicKey(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestBody PublicKeyRequestDto request
+    ) {
+        if (userDetails == null) {
+            throw new AccessDeniedException("인증된 사용자가 아닙니다.");
+        }
+
+        String email = userDetails.getUsername();
+        log.info("[USER-UPDATE-KEY] Updating public key for user: {}", email);
+
+        userService.updatePublicKey(email, request.publicKey());
+
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/diary/shared_diary/domain/Diary.java
+++ b/src/main/java/com/diary/shared_diary/domain/Diary.java
@@ -19,7 +19,7 @@ public class Diary {
     private String title;
 
     @Column(columnDefinition = "TEXT")
-    private String content;
+    private String encryptedContent;
 
     private LocalDateTime createdAt;
 
@@ -37,4 +37,9 @@ public class Diary {
     @OneToMany(mappedBy = "diary", cascade = CascadeType.ALL)
     private List<Comment> comments;
 
+    private String iv;
+    private String authTag;
+
+    @Column(columnDefinition = "TEXT")
+    private String encryptedAesKey;
 }

--- a/src/main/java/com/diary/shared_diary/domain/Group.java
+++ b/src/main/java/com/diary/shared_diary/domain/Group.java
@@ -3,6 +3,7 @@ package com.diary.shared_diary.domain;
 import com.fasterxml.jackson.annotation.JsonManagedReference;
 import jakarta.persistence.*;
 import lombok.*;
+import org.springframework.security.access.AccessDeniedException;
 
 import java.time.LocalDateTime;
 import java.util.HashSet;
@@ -39,5 +40,11 @@ public class Group {
     public void addMember(User user) {
         this.members.add(user);
         user.getGroups().add(this);
+    }
+
+    public void validateMember(User user) {
+        if (!this.members.contains(user)) {
+            throw new AccessDeniedException("그룹 멤버가 아닙니다.");
+        }
     }
 }

--- a/src/main/java/com/diary/shared_diary/domain/User.java
+++ b/src/main/java/com/diary/shared_diary/domain/User.java
@@ -23,6 +23,9 @@ public class User {
     private String username;
     private String email;
 
+    @Column(columnDefinition = "TEXT")
+    private String publicKey;
+
     private String refreshToken;
 
     private String authorizationCode;

--- a/src/main/java/com/diary/shared_diary/dto/auth/LoginSuccessResponseDto.java
+++ b/src/main/java/com/diary/shared_diary/dto/auth/LoginSuccessResponseDto.java
@@ -1,5 +1,6 @@
 package com.diary.shared_diary.dto.auth;
 
+import com.diary.shared_diary.dto.user.UserResponseDto;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -10,4 +11,5 @@ import lombok.NoArgsConstructor;
 public class LoginSuccessResponseDto {
     private String accessToken;
     private String refreshToken;
+    private UserResponseDto user;
 }

--- a/src/main/java/com/diary/shared_diary/dto/diary/DiaryDetailResponseDto.java
+++ b/src/main/java/com/diary/shared_diary/dto/diary/DiaryDetailResponseDto.java
@@ -15,16 +15,19 @@ import java.util.stream.Collectors;
 public class DiaryDetailResponseDto {
     private Long id;
     private String title;
-    private String content;
+    private String encryptedContent;
     private String authorUsername;
     private LocalDateTime createdAt;
     private String imageUrl;
     private List<CommentResponseDto> comments;
+    private String iv;
+    private String authTag;
+    private String encryptedAesKey;
 
     public DiaryDetailResponseDto(Diary diary, S3Uploader uploader) {
         this.id = diary.getId();
         this.title = diary.getTitle();
-        this.content = diary.getContent();
+        this.encryptedContent = diary.getEncryptedContent();
         this.authorUsername = diary.getAuthor().getUsername();
         this.createdAt = diary.getCreatedAt();
         this.imageUrl = diary.getImagePath() != null
@@ -33,5 +36,9 @@ public class DiaryDetailResponseDto {
         this.comments = diary.getComments().stream()
                 .map(CommentResponseDto::new)
                 .collect(Collectors.toList());
+
+        this.iv = diary.getIv();
+        this.authTag = diary.getAuthTag();
+        this.encryptedAesKey = diary.getEncryptedAesKey();
     }
 }

--- a/src/main/java/com/diary/shared_diary/dto/diary/DiaryRequestDto.java
+++ b/src/main/java/com/diary/shared_diary/dto/diary/DiaryRequestDto.java
@@ -8,6 +8,10 @@ import org.springframework.web.multipart.MultipartFile;
 @Setter
 public class DiaryRequestDto {
     private String title;
-    private String content;
+    private String encryptedContent;
     private MultipartFile image;
+
+    private String iv;
+    private String authTag;
+    private String encryptedAesKey;
 }

--- a/src/main/java/com/diary/shared_diary/dto/diary/DiaryResponseDto.java
+++ b/src/main/java/com/diary/shared_diary/dto/diary/DiaryResponseDto.java
@@ -11,7 +11,7 @@ public class DiaryResponseDto {
 
     private Long id;
     private String title;
-    private String content;
+    private String encryptedContent;
     private String authorUsername;
     private LocalDateTime createdAt;
     private String imageUrl;
@@ -19,7 +19,7 @@ public class DiaryResponseDto {
     public DiaryResponseDto(Diary diary, S3Uploader uploader) {
         this.id = diary.getId();
         this.title = diary.getTitle();
-        this.content = diary.getContent();
+        this.encryptedContent = diary.getEncryptedContent();
         this.authorUsername = diary.getAuthor().getUsername();
         this.createdAt = diary.getCreatedAt();
         this.imageUrl = diary.getImagePath() != null

--- a/src/main/java/com/diary/shared_diary/dto/user/PublicKeyRequestDto.java
+++ b/src/main/java/com/diary/shared_diary/dto/user/PublicKeyRequestDto.java
@@ -1,0 +1,8 @@
+package com.diary.shared_diary.dto.user;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record PublicKeyRequestDto(
+        @NotBlank(message = "공개키는 필수 항목입니다.")
+        String publicKey
+) {}

--- a/src/main/java/com/diary/shared_diary/dto/user/UserResponseDto.java
+++ b/src/main/java/com/diary/shared_diary/dto/user/UserResponseDto.java
@@ -5,9 +5,14 @@ import com.diary.shared_diary.domain.User;
 public record UserResponseDto(
         Long id,
         String username,
-        String email
+        String email,
+        String publicKey
 ) {
     public UserResponseDto(User user) {
-        this(user.getId(), user.getUsername(), user.getEmail());
+        this(user.getId(), user.getUsername(), user.getEmail(), user.getPublicKey());
+    }
+
+    public static UserResponseDto from(User user) {
+        return new UserResponseDto(user);
     }
 }

--- a/src/main/java/com/diary/shared_diary/repository/DiaryRepository.java
+++ b/src/main/java/com/diary/shared_diary/repository/DiaryRepository.java
@@ -3,6 +3,7 @@ package com.diary.shared_diary.repository;
 import com.diary.shared_diary.domain.Diary;
 import com.diary.shared_diary.domain.User;
 import com.diary.shared_diary.domain.Group;
+import com.diary.shared_diary.exception.NotFoundException;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -12,4 +13,9 @@ public interface DiaryRepository extends JpaRepository<Diary, Long> {
 
     List<Diary> findByGroup(Group group);
     List<Diary> findByGroupOrderByCreatedAtDesc(Group group);
+
+    default Diary getOrThrow(Long id) {
+        return findById(id)
+                .orElseThrow(() -> new NotFoundException("ID가 [" + id + "]인 일기를 찾을 수 없습니다."));
+    }
 }

--- a/src/main/java/com/diary/shared_diary/repository/GroupRepository.java
+++ b/src/main/java/com/diary/shared_diary/repository/GroupRepository.java
@@ -2,7 +2,7 @@ package com.diary.shared_diary.repository;
 
 import com.diary.shared_diary.domain.Group;
 import com.diary.shared_diary.domain.User;
-import io.micrometer.common.lang.NonNull;
+import com.diary.shared_diary.exception.NotFoundException;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
@@ -13,13 +13,13 @@ public interface GroupRepository extends JpaRepository<Group, Long> {
 
     Optional<Group> findByCode(String code);
 
-    default @NonNull Group getById(@NonNull Long id) {
+    default Group getOrThrow(Long id) {
         return findById(id)
-                .orElseThrow(() -> new RuntimeException("Group not found"));
+                .orElseThrow(() -> new NotFoundException("해당 ID의 그룹을 찾을 수 없습니다: " + id));
     }
 
-    default Group getByCode(String code) {
+    default Group getByCodeOrThrow(String code) {
         return findByCode(code)
-                .orElseThrow(() -> new RuntimeException("Group not found"));
+                .orElseThrow(() -> new NotFoundException("해당 코드의 그룹을 찾을 수 없습니다: " + code));
     }
 }

--- a/src/main/java/com/diary/shared_diary/repository/UserRepository.java
+++ b/src/main/java/com/diary/shared_diary/repository/UserRepository.java
@@ -1,6 +1,7 @@
 package com.diary.shared_diary.repository;
 
 import com.diary.shared_diary.domain.User;
+import com.diary.shared_diary.exception.NotFoundException;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
@@ -10,8 +11,14 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
     Optional<User> findByRefreshToken(String refreshToken);
     Optional<User> findByAuthorizationCode(String authorizationCode);
-    default User getByEmail(String email) {
+
+    default User getByEmailOrThrow(String email) {
         return findByEmail(email)
-                .orElseThrow(() -> new RuntimeException("User not found"));
+                .orElseThrow(() -> new NotFoundException("이메일이 [" + email + "]인 사용자를 찾을 수 없습니다."));
+    }
+
+    default User getByIdOrThrow(Long id) {
+        return findById(id)
+                .orElseThrow(() -> new NotFoundException("ID가 [" + id + "]인 사용자를 찾을 수 없습니다."));
     }
 }

--- a/src/main/java/com/diary/shared_diary/service/CommentService.java
+++ b/src/main/java/com/diary/shared_diary/service/CommentService.java
@@ -1,5 +1,6 @@
 package com.diary.shared_diary.service;
 
+import com.amazonaws.services.kms.model.NotFoundException;
 import com.diary.shared_diary.domain.Comment;
 import com.diary.shared_diary.domain.Diary;
 import com.diary.shared_diary.domain.Group;
@@ -10,6 +11,7 @@ import com.diary.shared_diary.repository.CommentRepository;
 import com.diary.shared_diary.repository.DiaryRepository;
 import com.diary.shared_diary.repository.UserRepository;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
@@ -35,14 +37,14 @@ public class CommentService {
     public List<CommentResponseDto> getComments(Long diaryId, String email) {
         log.info("Fetching comments for diaryId: {}, user: {}", diaryId, email);
         Diary diary = diaryRepository.findById(diaryId)
-                .orElseThrow(() -> new RuntimeException("일기를 찾을 수 없습니다."));
+                .orElseThrow(() -> new NotFoundException("일기를 찾을 수 없습니다."));
         User user = userRepository.findByEmail(email)
-                .orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없습니다."));
+                .orElseThrow(() -> new NotFoundException("사용자를 찾을 수 없습니다."));
 
         Group group = diary.getGroup();
         if (!group.getMembers().contains(user)) {
             log.warn("User {} is not a member of group {}. Access denied for diary {}.", email, diary.getGroup().getId(), diaryId);
-            throw new RuntimeException("댓글을 볼 수 있는 권한이 없습니다.");
+            throw new AccessDeniedException("댓글을 볼 수 있는 권한이 없습니다.");
         }
 
         log.info("Successfully fetched comments for diaryId: {}", diaryId);
@@ -54,14 +56,14 @@ public class CommentService {
     public CommentResponseDto createComment(Long diaryId, String email, CommentRequestDto dto) {
         log.info("Start creating comment for user: {}, diary: {}", email, diaryId);
         Diary diary = diaryRepository.findById(diaryId)
-                .orElseThrow(() -> new RuntimeException("일기를 찾을 수 없습니다."));
+                .orElseThrow(() -> new NotFoundException("일기를 찾을 수 없습니다."));
         User user = userRepository.findByEmail(email)
-                .orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없습니다."));
+                .orElseThrow(() -> new NotFoundException("사용자를 찾을 수 없습니다."));
 
         Group group = diary.getGroup();
         if (!group.getMembers().contains(user)) {
             log.warn("User {} is not a member of group {}. Access denied for diary {}.", email, diary.getGroup().getId(), diaryId);
-            throw new RuntimeException("해당 그룹 멤버만 댓글을 달 수 있습니다.");
+            throw new AccessDeniedException("해당 그룹 멤버만 댓글을 달 수 있습니다.");
         }
 
         Comment parent = Optional.ofNullable(dto.parentId())
@@ -87,6 +89,6 @@ public class CommentService {
 
         Comment saved = commentRepository.save(comment);
         log.info("Comment created with id: {}", saved.getId());
-        return new CommentResponseDto(comment);
+        return new CommentResponseDto(saved);
     }
 }

--- a/src/main/java/com/diary/shared_diary/service/CommentService.java
+++ b/src/main/java/com/diary/shared_diary/service/CommentService.java
@@ -1,6 +1,6 @@
 package com.diary.shared_diary.service;
 
-import com.amazonaws.services.kms.model.NotFoundException;
+import com.diary.shared_diary.exception.NotFoundException;
 import com.diary.shared_diary.domain.Comment;
 import com.diary.shared_diary.domain.Diary;
 import com.diary.shared_diary.domain.Group;

--- a/src/main/java/com/diary/shared_diary/service/DiaryService.java
+++ b/src/main/java/com/diary/shared_diary/service/DiaryService.java
@@ -52,7 +52,10 @@ public class DiaryService {
 
         Diary diary = Diary.builder()
                 .title(dto.getTitle())
-                .content(dto.getContent())
+                .encryptedContent(dto.getEncryptedContent())
+                .iv(dto.getIv())
+                .authTag(dto.getAuthTag())
+                .encryptedAesKey(dto.getEncryptedAesKey())
                 .createdAt(LocalDateTime.now())
                 .author(author)
                 .group(group)

--- a/src/main/java/com/diary/shared_diary/service/DiaryService.java
+++ b/src/main/java/com/diary/shared_diary/service/DiaryService.java
@@ -6,11 +6,13 @@ import com.diary.shared_diary.domain.User;
 import com.diary.shared_diary.dto.diary.DiaryDetailResponseDto;
 import com.diary.shared_diary.dto.diary.DiaryRequestDto;
 import com.diary.shared_diary.dto.diary.DiaryResponseDto;
+import com.diary.shared_diary.exception.NotFoundException;
 import com.diary.shared_diary.repository.DiaryRepository;
 import com.diary.shared_diary.repository.GroupRepository;
 import com.diary.shared_diary.repository.UserRepository;
 import com.diary.shared_diary.util.S3Uploader;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -34,14 +36,12 @@ public class DiaryService {
 
     public DiaryResponseDto createDiary(Long groupId, String email, DiaryRequestDto dto, MultipartFile image) {
         log.info("Start creating diary for user: {}, group: {}", email, groupId);
-        User author = userRepository.findByEmail(email)
-                .orElseThrow(() -> new RuntimeException("User not found"));
-        Group group = groupRepository.findById(groupId)
-                .orElseThrow(() -> new RuntimeException("Group not found"));
+        User author = userRepository.getByEmailOrThrow(email);
+        Group group = groupRepository.getOrThrow(groupId);
 
         if (!group.getMembers().contains(author)) {
             log.warn("User {} is not a member of group {}. Access denied.", email, groupId);
-            throw new RuntimeException("그룹에 속한 사용자만 작성할 수 있습니다.");
+            throw new AccessDeniedException("그룹에 속한 사용자만 작성할 수 있습니다.");
         }
 
         String imagePath = null;
@@ -71,16 +71,13 @@ public class DiaryService {
 
     public DiaryDetailResponseDto getDiaryDetail(Long diaryId, String email) {
         log.info("Fetching diary detail for diaryId: {}, user: {}", diaryId, email);
-        Diary diary = diaryRepository.findById(diaryId)
-                .orElseThrow(() -> new RuntimeException("Diary not found"));
-
-        User user = userRepository.findByEmail(email)
-                .orElseThrow(() -> new RuntimeException("User not found"));
+        Diary diary = diaryRepository.getOrThrow(diaryId);
+        User user = userRepository.getByEmailOrThrow(email);
 
         // 권한 체크: 그룹 멤버만 조회 가능
         if (!diary.getGroup().getMembers().contains(user)) {
             log.warn("User {} is not a member of group {}. Access denied for diary {}.", email, diary.getGroup().getId(), diaryId);
-            throw new RuntimeException("해당 그룹에 속한 사용자만 조회할 수 있습니다.");
+            throw new AccessDeniedException("해당 그룹에 속한 사용자만 조회할 수 있습니다.");
         }
 
         log.info("Successfully fetched diary detail for diaryId: {}", diaryId);

--- a/src/main/java/com/diary/shared_diary/service/GroupService.java
+++ b/src/main/java/com/diary/shared_diary/service/GroupService.java
@@ -6,13 +6,16 @@ import com.diary.shared_diary.domain.User;
 import com.diary.shared_diary.dto.group.GroupDetailResponseDto;
 import com.diary.shared_diary.dto.group.GroupRequestDto;
 import com.diary.shared_diary.dto.group.GroupResponseDto;
+import com.diary.shared_diary.exception.NotFoundException;
 import com.diary.shared_diary.repository.DiaryRepository;
 import com.diary.shared_diary.repository.GroupRepository;
 import com.diary.shared_diary.repository.UserRepository;
 import com.diary.shared_diary.util.CodeGenerator;
 import com.diary.shared_diary.util.S3Uploader;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.HashSet;
@@ -37,9 +40,7 @@ public class GroupService {
 
     public List<GroupResponseDto> getGroupsByUserEmail(String email) {
         log.info("Fetching groups for user: {}", email);
-        User user = userRepository.findByEmail(email)
-                .orElseThrow(() -> new RuntimeException("User not found"));
-
+        User user = userRepository.getByEmailOrThrow(email);
         List<Group> groups = groupRepository.findAllByMembersContains(user);
         log.info("Found {} groups for user: {}", groups.size(), email);
         return groups.stream()
@@ -49,13 +50,11 @@ public class GroupService {
 
     public GroupDetailResponseDto getGroupDetail(Long groupId, String email) {
         log.info("Fetching group detail for groupId: {}, user: {}", groupId, email);
-        Group group = groupRepository.getById(groupId);
-        User user = userRepository.getByEmail(email);
+        Group group = groupRepository.getOrThrow(groupId);
+        User user = userRepository.getByEmailOrThrow(email);
 
-        if (!group.getMembers().contains(user)) {
-            log.warn("User {} is not a member of group {}. Access denied.", email, groupId);
-            throw new RuntimeException("해당 그룹에 접근할 권한이 없습니다.");
-        }
+        group.validateMember(user);
+
         List<Diary> diaries = diaryRepository.findByGroupOrderByCreatedAtDesc(group);
 
         log.info("Successfully fetched group detail for groupId: {}", groupId);
@@ -64,10 +63,8 @@ public class GroupService {
 
     public GroupResponseDto createGroup(String userEmail, GroupRequestDto dto) {
         log.info("Creating group for user: {}", userEmail);
-        User creator = userRepository.findByEmail(userEmail)
-                .orElseThrow(() -> new RuntimeException("User not found"));
+        User creator = userRepository.getByEmailOrThrow(userEmail);
 
-        // ✅ 유일한 코드 생성
         String code;
         do {
             code = CodeGenerator.generateGroupCode();
@@ -86,11 +83,11 @@ public class GroupService {
         return new GroupResponseDto(saved.getId(), saved.getName(), code);
     }
 
-
+    @Transactional
     public void joinGroupByCode(String code, String email) {
         log.info("User {} attempts to join group with code: {}", email, code);
-        Group group = groupRepository.getByCode(code);
-        User user = userRepository.getByEmail(email);
+        Group group = groupRepository.getByCodeOrThrow(code);
+        User user = userRepository.getByEmailOrThrow(email);
 
         if (!group.getMembers().contains(user)) {
             group.addMember(user);
@@ -102,19 +99,16 @@ public class GroupService {
     }
 
 
-
+    @Transactional
     public void addMembers(Long groupId, List<Long> userIds) {
         log.info("Adding members to group: {}", groupId);
-        Group group = groupRepository.findById(groupId)
-                .orElseThrow(() -> new RuntimeException("Group not found"));
-
+        Group group = groupRepository.getOrThrow(groupId);
         List<User> usersToAdd = userRepository.findAllById(userIds);
 
         for (User user : usersToAdd) {
             group.addMember(user);
         }
 
-        groupRepository.save(group);
         log.info("Successfully added {} members to group: {}", usersToAdd.size(), groupId);
     }
 

--- a/src/main/java/com/diary/shared_diary/service/UserService.java
+++ b/src/main/java/com/diary/shared_diary/service/UserService.java
@@ -42,19 +42,14 @@ public class UserService {
         return UserResponseDto.from(user);
     }
 
-    public List<UserResponseDto> getAllUsers() {
-        log.info("Fetching all users.");
-        List<UserResponseDto> users = userRepository.findAll().stream()
-                .map(user -> new UserResponseDto(
-                        user.getId(),
-                        user.getUsername(),
-                        user.getEmail(),
-                        user.getPublicKey()
-                ))
-                .toList();
-        log.info("Found {} users.", users.size());
-        return users;
-    }
+//    public List<UserResponseDto> getAllUsers() {
+//        log.info("Fetching all users.");
+//        List<UserResponseDto> users = userRepository.findAll().stream()
+//                .map(UserResponseDto::from)
+//                .toList();
+//        log.info("Found {} users.", users.size());
+//        return users;
+//    }
 
 
     public boolean isEmailExists(String email) {

--- a/src/main/java/com/diary/shared_diary/service/UserService.java
+++ b/src/main/java/com/diary/shared_diary/service/UserService.java
@@ -6,6 +6,7 @@ import com.diary.shared_diary.dto.user.UserResponseDto;
 import com.diary.shared_diary.repository.UserRepository;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -30,7 +31,15 @@ public class UserService {
 
         User saved = userRepository.save(user);
         log.info("User created with id: {}", saved.getId());
-        return new UserResponseDto(saved.getId(), saved.getUsername(), saved.getEmail());
+        return new UserResponseDto(saved);
+    }
+
+    @Transactional(readOnly = true)
+    public UserResponseDto getUserResponseByEmail(String email) {
+        log.info("Fetching user profile for email: {}", email);
+
+        User user = userRepository.getByEmailOrThrow(email);
+        return UserResponseDto.from(user);
     }
 
     public List<UserResponseDto> getAllUsers() {
@@ -39,7 +48,8 @@ public class UserService {
                 .map(user -> new UserResponseDto(
                         user.getId(),
                         user.getUsername(),
-                        user.getEmail()
+                        user.getEmail(),
+                        user.getPublicKey()
                 ))
                 .toList();
         log.info("Found {} users.", users.size());
@@ -52,5 +62,11 @@ public class UserService {
         boolean exists = userRepository.existsByEmail(email);
         log.info("Email {} exists: {}", email, exists);
         return exists;
+    }
+
+    @Transactional
+    public void updatePublicKey(String email, String publicKey) {
+        User user = userRepository.getByEmailOrThrow(email);
+        user.setPublicKey(publicKey);
     }
 }


### PR DESCRIPTION
## 변경 사항

- 일기 내용 암호화를 적용했습니다.
  - User에 public key를 추가했습니다.
  - Diary에 iv, authtag, aeskey를 추가했습니다.
- 로그인 시 사용자 데이터를 클라이언트에 전송하도록 변경했습니다.
- Repository에서 `getOrThrow`를 사용하도록 리팩토링하고, Runtime exception 대신 적절한 exception을 사용하도록 수정했습니다.