### PR TITLE
Feat: 그룹 멤버 암호키 공유 기능

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
 # ✍️ 우리어리 - 교환 일기 프로젝트
 
-카카오 로그인 기반의 그룹형 교환 일기 서비스입니다.  
+카카오 로그인 기반의 그룹형 교환 일기 서비스입니다.
 사용자는 그룹을 만들고 함께 일기를 쓰고, 댓글로 소통할 수 있습니다.
 
 ---
 
 ## ✅ 기술 스택
 
-| 구분       | 기술 |
-|------------|------|
-| **Backend**  | Spring Boot, Spring Security, JWT, OAuth2 (Kakao) |
+| 구분 | 기술 |
+| --- | --- |
+| **Backend** | Spring Boot, Spring Security, JWT, OAuth2 (Kakao) |
 | **Database** | H2 (개발용), MySQL (RDS - 운영용), JPA (Hibernate) |
-| **Storage**  | AWS S3 (Presigned URL 기반 이미지 업로드) |
-| **Infra**    | EC2 (Ubuntu), RDS (MySQL), HTTPS (443), GitHub Actions 예정 |
+| **Storage** | AWS S3 (Presigned URL 기반 이미지 업로드) |
+| **Infra** | EC2 (Ubuntu), RDS (MySQL), HTTPS (443), GitHub Actions 예정 |
 
 ---
 
@@ -35,25 +35,63 @@
 - 댓글 / 대댓글 작성 및 트리 구조 렌더링
 - 일기별 댓글 목록 조회
 
+### 🔒 E2EE (End-to-End Encryption)
+- 모든 일기 내용은 사용자 기기에서 암호화되어 서버에 저장됩니다.
+- 그룹에 새로운 멤버가 추가될 때, 기존 멤버가 새로운 멤버의 공개키를 사용하여 일기 암호화 키를 다시 암호화하여 공유합니다.
+- 이를 통해 새로운 멤버도 과거의 일기를 복호화하여 볼 수 있습니다.
+
 ---
 
 ## 🗄️ DB 설계
 
 ### 📌 주요 테이블
 
-| 테이블       | 설명                                                                                                                   |
-| ------------ | -------------------------------------------------------------------------------------------------------------------- |
-| `users`      | 사용자 정보 테이블 (예: `email`, `nickname`, `created_at` 등)                                                                  |
-| `user_group` | **그룹 정보 테이블** (예: `id`, `name`, `code`, `created_at` 등) |
-| `group_user` | **사용자-그룹 간 다대다 관계를 나타내는 조인 테이블**<br>`group_id`, `user_id` 로 구성                                                       |
-| `diary`      | 일기 정보 테이블 (예: `title`, `content`, `image_path`, `created_at` 등)<br>각 일기는 특정 그룹과 작성자(`user`)에 속함                      |
-| `comment`    | 댓글 및 대댓글 테이블<br>`diary_id`, `user_id`, `parent_id`(대댓글 여부 판별) 등 포함                                                   |
+| 테이블 | 설명 |
+| --- | --- |
+| `users` | 사용자 정보 테이블 |
+| `groups` | 그룹 정보 테이블 |
+| `group_members` | 사용자와 그룹의 관계를 나타내는 테이블 |
+| `diary` | 일기 정보 테이블 |
+| `diary_keys` | 일기 암호화 키 정보 테이블 |
+| `comment` | 댓글 정보 테이블 |
+| `notification` | 알림 정보 테이블 |
 
 
 ### 🧩 ERD
 
 ![ERD](https://github.com/user-attachments/assets/e2959342-736c-45f7-af5c-654b7fc3a4f8)
 
+
+---
+
+## 📖 API Endpoints
+
+### Auth
+- `POST /api/auth/login`: 카카오 로그인
+- `POST /api/auth/refresh`: JWT 토큰 재발급
+
+### User
+- `GET /api/user/me`: 내 정보 조회
+- `POST /api/user/me/publicKey`: 공개키 등록
+
+### Groups
+- `POST /api/groups`: 그룹 생성
+- `GET /api/groups/{groupId}`: 그룹 상세 조회
+- `GET /api/groups/{groupId}/members`: 그룹 멤버 목록 조회
+- `POST /api/groups/join-requests`: 그룹 참여 요청
+- `GET /api/groups/join-requests/{targetId}/approval-info`: 그룹 가입 승인에 필요한 정보 조회
+- `POST /api/groups/join-requests/{targetId}/approve`: 그룹 가입 요청 승인 및 키 교환
+
+### Diaries
+- `POST /api/groups/{groupId}/diaries`: 일기 작성
+- `GET /api/diaries/{diaryId}`: 일기 상세 조회
+
+### Comments
+- `POST /api/diaries/{diaryId}/comments`: 댓글 작성
+
+### Notifications
+- `GET /api/notifications`: 알림 목록 조회
+- `POST /api/notifications/{notificationId}/read`: 알림 읽음 처리
 
 ---
 
@@ -78,4 +116,3 @@
 - EC2 (Ubuntu) 서버에 JAR 파일 배포
 - MySQL RDS와 연결
 - `application-prod.properties` 분리 사용
-

--- a/src/main/java/com/diary/shared_diary/controller/GroupController.java
+++ b/src/main/java/com/diary/shared_diary/controller/GroupController.java
@@ -30,16 +30,33 @@ public class GroupController {
         groupMemberService.requestToJoinGroup(userDetails.getId(), groupId);
     }
 
-    @Operation(summary = "그룹 가입 요청 승인")
+    @Operation(summary = "그룹 가입 승인에 필요한 정보 조회")
+    @GetMapping("/join-requests/{targetId}/approval-info")
+    public ApprovalInfoResponse getApprovalInfo(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long targetId) {
+        return groupMemberService.getApprovalInfo(userDetails.getId(), targetId);
+    }
+
+    @Operation(summary = "그룹 가입 요청 승인 및 키 교환")
     @PostMapping("/join-requests/{targetId}/approve")
-    public void approveJoinRequest(@AuthenticationPrincipal CustomUserDetails userDetails, @PathVariable Long targetId) {
-        groupMemberService.approveJoinRequest(userDetails.getId(), targetId);
+    public void approveJoinRequest(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long targetId,
+            @RequestBody ApproveMemberRequest request) {
+        groupMemberService.approveMemberWithKeys(userDetails.getId(), targetId, request);
     }
 
     @Operation(summary = "그룹 가입 대기자 목록 조회")
     @GetMapping("/{groupId}/pending-members")
     public List<PendingMemberResponseDto> getPendingMembers(@AuthenticationPrincipal CustomUserDetails userDetails, @PathVariable Long groupId) {
         return groupMemberService.getPendingMembers(userDetails.getId(), groupId);
+    }
+
+    @Operation(summary = "그룹 멤버 목록 조회")
+    @GetMapping("/{groupId}/members")
+    public List<GroupMemberResponseDto> getGroupMembers(@PathVariable Long groupId, @AuthenticationPrincipal CustomUserDetails userDetails) {
+        return groupMemberService.getGroupMembers(groupId, userDetails.getId());
     }
 
     @GetMapping("/user")

--- a/src/main/java/com/diary/shared_diary/domain/Diary.java
+++ b/src/main/java/com/diary/shared_diary/domain/Diary.java
@@ -20,6 +20,12 @@ public class Diary {
     @Column(columnDefinition = "TEXT")
     private String encryptedContent;
 
+    @Column(columnDefinition = "TEXT", nullable = false)
+    private String iv;
+
+    @Column(columnDefinition = "TEXT", nullable = false)
+    private String authTag;
+
     private LocalDateTime createdAt;
 
     @Column
@@ -36,9 +42,5 @@ public class Diary {
     @OneToMany(mappedBy = "diary", cascade = CascadeType.ALL)
     private List<Comment> comments;
 
-    private String iv;
-    private String authTag;
 
-    @Column(columnDefinition = "TEXT")
-    private String encryptedAesKey;
 }

--- a/src/main/java/com/diary/shared_diary/domain/DiaryKey.java
+++ b/src/main/java/com/diary/shared_diary/domain/DiaryKey.java
@@ -1,0 +1,30 @@
+package com.diary.shared_diary.domain;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "diary_keys")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class DiaryKey {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "diary_id", nullable = false)
+    private Diary diary;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(columnDefinition = "TEXT", nullable = false)
+    private String encryptedAesKey;
+}

--- a/src/main/java/com/diary/shared_diary/dto/diary/DiaryDetailResponseDto.java
+++ b/src/main/java/com/diary/shared_diary/dto/diary/DiaryDetailResponseDto.java
@@ -1,13 +1,13 @@
 package com.diary.shared_diary.dto.diary;
 
 import com.diary.shared_diary.domain.Diary;
+import com.diary.shared_diary.domain.DiaryKey;
+import com.diary.shared_diary.dto.comment.CommentResponseDto;
 import com.diary.shared_diary.util.S3Uploader;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
-
-import com.diary.shared_diary.dto.comment.CommentResponseDto;
-
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -16,18 +16,26 @@ public class DiaryDetailResponseDto {
     private Long id;
     private String title;
     private String encryptedContent;
+    private String iv; // for content
+    private String authTag; // for content
     private String authorUsername;
-    private LocalDateTime createdAt;
     private String imageUrl;
     private List<CommentResponseDto> comments;
-    private String iv;
-    private String authTag;
-    private String encryptedAesKey;
+    private LocalDateTime createdAt;
+    private EncryptedKeyInfo keyInfo; // for key
 
-    public DiaryDetailResponseDto(Diary diary, S3Uploader uploader) {
+    @Getter
+    @AllArgsConstructor
+    public static class EncryptedKeyInfo {
+        private String encryptedAesKey;
+    }
+
+    public DiaryDetailResponseDto(Diary diary, DiaryKey diaryKey, S3Uploader uploader) {
         this.id = diary.getId();
         this.title = diary.getTitle();
         this.encryptedContent = diary.getEncryptedContent();
+        this.iv = diary.getIv(); // from Diary
+        this.authTag = diary.getAuthTag(); // from Diary
         this.authorUsername = diary.getAuthor().getUsername();
         this.createdAt = diary.getCreatedAt();
         this.imageUrl = diary.getImagePath() != null
@@ -37,8 +45,8 @@ public class DiaryDetailResponseDto {
                 .map(CommentResponseDto::new)
                 .collect(Collectors.toList());
 
-        this.iv = diary.getIv();
-        this.authTag = diary.getAuthTag();
-        this.encryptedAesKey = diary.getEncryptedAesKey();
+        this.keyInfo = new EncryptedKeyInfo(
+                diaryKey.getEncryptedAesKey()
+        );
     }
 }

--- a/src/main/java/com/diary/shared_diary/dto/diary/DiaryRequestDto.java
+++ b/src/main/java/com/diary/shared_diary/dto/diary/DiaryRequestDto.java
@@ -4,14 +4,15 @@ import lombok.Getter;
 import lombok.Setter;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.List;
+
 @Getter
 @Setter
 public class DiaryRequestDto {
     private String title;
     private String encryptedContent;
-    private MultipartFile image;
-
     private String iv;
     private String authTag;
-    private String encryptedAesKey;
+    private MultipartFile image;
+    private List<EncryptedDiaryKeyDto> keys;
 }

--- a/src/main/java/com/diary/shared_diary/dto/diary/EncryptedDiaryKeyDto.java
+++ b/src/main/java/com/diary/shared_diary/dto/diary/EncryptedDiaryKeyDto.java
@@ -1,0 +1,13 @@
+package com.diary.shared_diary.dto.diary;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class EncryptedDiaryKeyDto {
+    private Long userId;
+    private String encryptedAesKey;
+}

--- a/src/main/java/com/diary/shared_diary/dto/group/ApprovalInfoResponse.java
+++ b/src/main/java/com/diary/shared_diary/dto/group/ApprovalInfoResponse.java
@@ -1,0 +1,13 @@
+package com.diary.shared_diary.dto.group;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class ApprovalInfoResponse {
+    private String newMemberPublicKey;
+    private List<DiaryKeyDto> diaryKeys;
+}

--- a/src/main/java/com/diary/shared_diary/dto/group/ApproveMemberRequest.java
+++ b/src/main/java/com/diary/shared_diary/dto/group/ApproveMemberRequest.java
@@ -1,0 +1,12 @@
+package com.diary.shared_diary.dto.group;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class ApproveMemberRequest {
+    private List<ReEncryptedKeyDto> reEncryptedKeys;
+}

--- a/src/main/java/com/diary/shared_diary/dto/group/DiaryKeyDto.java
+++ b/src/main/java/com/diary/shared_diary/dto/group/DiaryKeyDto.java
@@ -1,0 +1,18 @@
+package com.diary.shared_diary.dto.group;
+
+import com.diary.shared_diary.domain.DiaryKey;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class DiaryKeyDto {
+    private Long diaryId;
+    private String encryptedAesKey;
+
+    public static DiaryKeyDto from(DiaryKey diaryKey) {
+        return new DiaryKeyDto(diaryKey.getDiary().getId(), diaryKey.getEncryptedAesKey());
+    }
+}

--- a/src/main/java/com/diary/shared_diary/dto/group/GroupMemberResponseDto.java
+++ b/src/main/java/com/diary/shared_diary/dto/group/GroupMemberResponseDto.java
@@ -1,0 +1,21 @@
+package com.diary.shared_diary.dto.group;
+
+import com.diary.shared_diary.domain.GroupMember;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class GroupMemberResponseDto {
+    private Long userId;
+    private String username;
+    private String publicKey;
+
+    public static GroupMemberResponseDto from(GroupMember groupMember) {
+        return new GroupMemberResponseDto(
+                groupMember.getUser().getId(),
+                groupMember.getUser().getUsername(),
+                groupMember.getUser().getPublicKey()
+        );
+    }
+}

--- a/src/main/java/com/diary/shared_diary/dto/group/ReEncryptedKeyDto.java
+++ b/src/main/java/com/diary/shared_diary/dto/group/ReEncryptedKeyDto.java
@@ -1,0 +1,23 @@
+package com.diary.shared_diary.dto.group;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+
+@Setter
+
+@NoArgsConstructor
+
+public class ReEncryptedKeyDto {
+
+    private Long diaryId;
+
+    private String encryptedAesKey;
+
+    private String iv;
+
+    private String authTag;
+
+}

--- a/src/main/java/com/diary/shared_diary/dto/group/ReEncryptedKeyDto.java
+++ b/src/main/java/com/diary/shared_diary/dto/group/ReEncryptedKeyDto.java
@@ -5,19 +5,9 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Getter
-
 @Setter
-
 @NoArgsConstructor
-
 public class ReEncryptedKeyDto {
-
     private Long diaryId;
-
     private String encryptedAesKey;
-
-    private String iv;
-
-    private String authTag;
-
 }

--- a/src/main/java/com/diary/shared_diary/repository/DiaryKeyRepository.java
+++ b/src/main/java/com/diary/shared_diary/repository/DiaryKeyRepository.java
@@ -1,0 +1,14 @@
+package com.diary.shared_diary.repository;
+
+import com.diary.shared_diary.domain.Diary;
+import com.diary.shared_diary.domain.DiaryKey;
+import com.diary.shared_diary.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface DiaryKeyRepository extends JpaRepository<DiaryKey, Long> {
+    List<DiaryKey> findByDiary_Group_IdAndUser_Id(Long groupId, Long userId);
+    Optional<DiaryKey> findByDiaryAndUser(Diary diary, User user);
+}

--- a/src/main/java/com/diary/shared_diary/repository/GroupMemberRepository.java
+++ b/src/main/java/com/diary/shared_diary/repository/GroupMemberRepository.java
@@ -5,6 +5,8 @@ import com.diary.shared_diary.domain.GroupMember;
 import com.diary.shared_diary.domain.MemberStatus;
 import com.diary.shared_diary.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -16,4 +18,7 @@ public interface GroupMemberRepository extends JpaRepository<GroupMember, Long> 
     boolean existsByUserAndGroupAndStatusIn(User user, Group group, List<MemberStatus> statuses);
     List<GroupMember> findByGroupAndStatus(Group group, MemberStatus status);
     List<GroupMember> findByUser(User user);
+
+    @Query("SELECT gm FROM GroupMember gm JOIN FETCH gm.user WHERE gm.group.id = :groupId AND gm.status = :status")
+    List<GroupMember> findByGroupIdAndStatusWithUser(@Param("groupId") Long groupId, @Param("status") MemberStatus status);
 }

--- a/src/main/java/com/diary/shared_diary/service/DiaryService.java
+++ b/src/main/java/com/diary/shared_diary/service/DiaryService.java
@@ -6,10 +6,7 @@ import com.diary.shared_diary.dto.diary.DiaryRequestDto;
 import com.diary.shared_diary.dto.diary.DiaryResponseDto;
 import com.diary.shared_diary.dto.diary.EncryptedDiaryKeyDto;
 import com.diary.shared_diary.exception.NotFoundException;
-import com.diary.shared_diary.repository.DiaryKeyRepository;
-import com.diary.shared_diary.repository.DiaryRepository;
-import com.diary.shared_diary.repository.GroupRepository;
-import com.diary.shared_diary.repository.UserRepository;
+import com.diary.shared_diary.repository.*;
 import com.diary.shared_diary.util.S3Uploader;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -32,6 +29,7 @@ public class DiaryService {
     private final GroupRepository groupRepository;
     private final UserRepository userRepository;
     private final DiaryKeyRepository diaryKeyRepository;
+    private final GroupMemberRepository groupMemberRepository;
     private final S3Uploader s3Uploader;
     private final GroupMemberService groupMemberService;
 
@@ -63,17 +61,11 @@ public class DiaryService {
         Diary savedDiary = diaryRepository.save(diary);
         log.info("Diary created with id: {}", savedDiary.getId());
 
-        List<GroupMember> acceptedMembers = group.getGroupMembers().stream()
-                .filter(gm -> gm.getStatus() == MemberStatus.ACCEPTED)
-                .toList();
+        List<GroupMember> acceptedMembers = groupMemberRepository.findByGroupIdAndStatusWithUser(groupId, MemberStatus.ACCEPTED);
 
         Map<Long, User> memberMap = acceptedMembers.stream()
                 .map(GroupMember::getUser)
                 .collect(Collectors.toMap(User::getId, Function.identity()));
-
-        // [DEBUG] Log server-side member list
-        log.info("[DEBUG] Found {} accepted members in the group.", memberMap.size());
-        memberMap.keySet().forEach(id -> log.info("[DEBUG] Accepted member ID on server: {}", id));
 
         if (dto.getKeys() != null) {
             for (EncryptedDiaryKeyDto keyDto : dto.getKeys()) {

--- a/src/main/java/com/diary/shared_diary/service/DiaryService.java
+++ b/src/main/java/com/diary/shared_diary/service/DiaryService.java
@@ -63,16 +63,6 @@ public class DiaryService {
         Diary savedDiary = diaryRepository.save(diary);
         log.info("Diary created with id: {}", savedDiary.getId());
 
-        // [DEBUG] Log received keys from client
-        if (dto.getKeys() == null) {
-            log.warn("[DEBUG] Keys list from client is null.");
-        } else {
-            log.info("[DEBUG] Received {} keys from client.", dto.getKeys().size());
-            dto.getKeys().forEach(k -> 
-                log.info("[DEBUG] Client Key DTO: userId={}, key is present={}", k.getUserId(), k.getEncryptedAesKey() != null)
-            );
-        }
-
         List<GroupMember> acceptedMembers = group.getGroupMembers().stream()
                 .filter(gm -> gm.getStatus() == MemberStatus.ACCEPTED)
                 .toList();

--- a/src/main/java/com/diary/shared_diary/service/DiaryService.java
+++ b/src/main/java/com/diary/shared_diary/service/DiaryService.java
@@ -1,11 +1,12 @@
 package com.diary.shared_diary.service;
 
-import com.diary.shared_diary.domain.Diary;
-import com.diary.shared_diary.domain.Group;
-import com.diary.shared_diary.domain.User;
+import com.diary.shared_diary.domain.*;
 import com.diary.shared_diary.dto.diary.DiaryDetailResponseDto;
 import com.diary.shared_diary.dto.diary.DiaryRequestDto;
 import com.diary.shared_diary.dto.diary.DiaryResponseDto;
+import com.diary.shared_diary.dto.diary.EncryptedDiaryKeyDto;
+import com.diary.shared_diary.exception.NotFoundException;
+import com.diary.shared_diary.repository.DiaryKeyRepository;
 import com.diary.shared_diary.repository.DiaryRepository;
 import com.diary.shared_diary.repository.GroupRepository;
 import com.diary.shared_diary.repository.UserRepository;
@@ -13,9 +14,14 @@ import com.diary.shared_diary.util.S3Uploader;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -25,9 +31,11 @@ public class DiaryService {
     private final DiaryRepository diaryRepository;
     private final GroupRepository groupRepository;
     private final UserRepository userRepository;
+    private final DiaryKeyRepository diaryKeyRepository;
     private final S3Uploader s3Uploader;
     private final GroupMemberService groupMemberService;
 
+    @Transactional
     public DiaryResponseDto createDiary(Long groupId, String email, DiaryRequestDto dto, MultipartFile image) {
         log.info("Start creating diary for user: {}, group: {}", email, groupId);
         User author = userRepository.getByEmailOrThrow(email);
@@ -46,19 +54,56 @@ public class DiaryService {
                 .encryptedContent(dto.getEncryptedContent())
                 .iv(dto.getIv())
                 .authTag(dto.getAuthTag())
-                .encryptedAesKey(dto.getEncryptedAesKey())
                 .createdAt(LocalDateTime.now())
                 .author(author)
                 .group(group)
                 .imagePath(imagePath)
                 .build();
 
-        Diary saved = diaryRepository.save(diary);
-        log.info("Diary created with id: {}", saved.getId());
-        return new DiaryResponseDto(saved, s3Uploader);
+        Diary savedDiary = diaryRepository.save(diary);
+        log.info("Diary created with id: {}", savedDiary.getId());
+
+        // [DEBUG] Log received keys from client
+        if (dto.getKeys() == null) {
+            log.warn("[DEBUG] Keys list from client is null.");
+        } else {
+            log.info("[DEBUG] Received {} keys from client.", dto.getKeys().size());
+            dto.getKeys().forEach(k -> 
+                log.info("[DEBUG] Client Key DTO: userId={}, key is present={}", k.getUserId(), k.getEncryptedAesKey() != null)
+            );
+        }
+
+        List<GroupMember> acceptedMembers = group.getGroupMembers().stream()
+                .filter(gm -> gm.getStatus() == MemberStatus.ACCEPTED)
+                .toList();
+
+        Map<Long, User> memberMap = acceptedMembers.stream()
+                .map(GroupMember::getUser)
+                .collect(Collectors.toMap(User::getId, Function.identity()));
+
+        // [DEBUG] Log server-side member list
+        log.info("[DEBUG] Found {} accepted members in the group.", memberMap.size());
+        memberMap.keySet().forEach(id -> log.info("[DEBUG] Accepted member ID on server: {}", id));
+
+        if (dto.getKeys() != null) {
+            for (EncryptedDiaryKeyDto keyDto : dto.getKeys()) {
+                User member = memberMap.get(keyDto.getUserId());
+                if (member != null) {
+                    log.info("[DEBUG] Match found for userId {}. Saving key.", keyDto.getUserId());
+                    DiaryKey diaryKey = DiaryKey.builder()
+                            .diary(savedDiary)
+                            .user(member)
+                            .encryptedAesKey(keyDto.getEncryptedAesKey())
+                            .build();
+                    diaryKeyRepository.save(diaryKey);
+                } else {
+                    log.warn("[DEBUG] No matching accepted member found for userId {}. Skipping key.", keyDto.getUserId());
+                }
+            }
+        }
+
+        return new DiaryResponseDto(savedDiary, s3Uploader);
     }
-
-
 
     public DiaryDetailResponseDto getDiaryDetail(Long diaryId, String email) {
         log.info("Fetching diary detail for diaryId: {}, user: {}", diaryId, email);
@@ -67,8 +112,11 @@ public class DiaryService {
 
         groupMemberService.validateAcceptedMember(user, diary.getGroup());
 
+        DiaryKey diaryKey = diaryKeyRepository.findByDiaryAndUser(diary, user)
+                .orElseThrow(() -> new NotFoundException("일기 키를 찾을 수 없습니다."));
+
         log.info("Successfully fetched diary detail for diaryId: {}", diaryId);
-        return new DiaryDetailResponseDto(diary, s3Uploader);
+        return new DiaryDetailResponseDto(diary, diaryKey, s3Uploader);
     }
 
 }

--- a/src/main/java/com/diary/shared_diary/service/GroupMemberService.java
+++ b/src/main/java/com/diary/shared_diary/service/GroupMemberService.java
@@ -139,7 +139,7 @@ public class GroupMemberService {
         Group group = groupRepository.getOrThrow(groupId);
         validateAcceptedMember(requestingUser, group);
 
-        List<GroupMember> acceptedMembers = groupMemberRepository.findByGroupAndStatus(group, MemberStatus.ACCEPTED);
+        List<GroupMember> acceptedMembers = groupMemberRepository.findByGroupIdAndStatusWithUser(group.getId(), MemberStatus.ACCEPTED);
 
         return acceptedMembers.stream()
                 .map(GroupMemberResponseDto::from)

--- a/src/main/java/com/diary/shared_diary/service/GroupMemberService.java
+++ b/src/main/java/com/diary/shared_diary/service/GroupMemberService.java
@@ -2,12 +2,9 @@ package com.diary.shared_diary.service;
 
 import com.diary.shared_diary.domain.*;
 
-import com.diary.shared_diary.dto.group.PendingMemberResponseDto;
+import com.diary.shared_diary.dto.group.*;
 import com.diary.shared_diary.exception.NotFoundException;
-import com.diary.shared_diary.repository.GroupMemberRepository;
-import com.diary.shared_diary.repository.GroupRepository;
-import com.diary.shared_diary.repository.NotificationRepository;
-import com.diary.shared_diary.repository.UserRepository;
+import com.diary.shared_diary.repository.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.access.AccessDeniedException;
@@ -16,6 +13,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -28,6 +26,8 @@ public class GroupMemberService {
     private final NotificationRepository notificationRepository;
     private final UserRepository userRepository;
     private final GroupRepository groupRepository;
+    private final DiaryKeyRepository diaryKeyRepository;
+    private final DiaryRepository diaryRepository;
 
     @Transactional
     public void requestToJoinGroup(Long userId, Long groupId) {
@@ -63,28 +63,64 @@ public class GroupMemberService {
         }
     }
 
-    @Transactional
-    public void approveJoinRequest(Long adminId, Long groupMemberId) {
-        GroupMember request = groupMemberRepository.findById(groupMemberId)
-                .orElseThrow(() -> new NotFoundException("가입 요청을 찾을 수 없습니다."));
+    public ApprovalInfoResponse getApprovalInfo(Long adminId, Long groupMemberId) {
         User admin = userRepository.getByIdOrThrow(adminId);
-        Group group = request.getGroup();
-        User targetUser = request.getUser();
+        GroupMember groupMember = groupMemberRepository.findById(groupMemberId)
+                .orElseThrow(() -> new NotFoundException("가입 요청을 찾을 수 없습니다."));
+        Group group = groupMember.getGroup();
         validateAcceptedMember(admin, group);
 
-        request.approve();
+        User newMember = groupMember.getUser();
+        String newMemberPublicKey = newMember.getPublicKey();
+        if (newMemberPublicKey == null || newMemberPublicKey.isEmpty()) {
+            throw new IllegalStateException("새로운 멤버의 공개키가 등록되지 않았습니다.");
+        }
+
+        List<DiaryKey> diaryKeys = diaryKeyRepository.findByDiary_Group_IdAndUser_Id(group.getId(), adminId);
+        List<DiaryKeyDto> diaryKeyDtos = diaryKeys.stream()
+                .map(DiaryKeyDto::from)
+                .collect(Collectors.toList());
+
+        return new ApprovalInfoResponse(newMemberPublicKey, diaryKeyDtos);
+    }
+
+    @Transactional
+    public void approveMemberWithKeys(Long adminId, Long groupMemberId, ApproveMemberRequest request) {
+        User admin = userRepository.getByIdOrThrow(adminId);
+        GroupMember groupMember = groupMemberRepository.findById(groupMemberId)
+                .orElseThrow(() -> new NotFoundException("가입 요청을 찾을 수 없습니다."));
+        Group group = groupMember.getGroup();
+        validateAcceptedMember(admin, group);
+
+        User newMember = groupMember.getUser();
+        groupMember.approve();
+
+        List<Diary> diariesInGroup = diaryRepository.findByGroup(group);
+        Map<Long, Diary> diaryMap = diariesInGroup.stream()
+                .collect(Collectors.toMap(Diary::getId, d -> d));
+
+        for (ReEncryptedKeyDto keyDto : request.getReEncryptedKeys()) {
+            Diary diary = diaryMap.get(keyDto.getDiaryId());
+            if (diary != null) {
+                DiaryKey diaryKey = DiaryKey.builder()
+                        .diary(diary)
+                        .user(newMember)
+                        .encryptedAesKey(keyDto.getEncryptedAesKey())
+                        .build();
+                diaryKeyRepository.save(diaryKey);
+            }
+        }
 
         String message = "'" + group.getName() + "' 그룹 가입 요청이 승인되었습니다.";
         Notification notification = Notification.builder()
-                .receiver(targetUser)
+                .receiver(newMember)
                 .message(message)
                 .type(NotificationType.APPROVED)
                 .targetId(group.getId())
                 .isRead(false)
                 .createdAt(LocalDateTime.now())
                 .build();
-        Notification savedNotification = notificationRepository.save(notification);
-        log.info("Saved notification: {}", savedNotification);
+        notificationRepository.save(notification);
     }
 
     public List<PendingMemberResponseDto> getPendingMembers(Long userId, Long groupId) {
@@ -95,6 +131,18 @@ public class GroupMemberService {
 
         return groupMemberRepository.findByGroupAndStatus(group, MemberStatus.PENDING).stream()
                 .map(gm -> PendingMemberResponseDto.from(gm.getUser()))
+                .collect(Collectors.toList());
+    }
+
+    public List<GroupMemberResponseDto> getGroupMembers(Long groupId, Long requestingUserId) {
+        User requestingUser = userRepository.getByIdOrThrow(requestingUserId);
+        Group group = groupRepository.getOrThrow(groupId);
+        validateAcceptedMember(requestingUser, group);
+
+        List<GroupMember> acceptedMembers = groupMemberRepository.findByGroupAndStatus(group, MemberStatus.ACCEPTED);
+
+        return acceptedMembers.stream()
+                .map(GroupMemberResponseDto::from)
                 .collect(Collectors.toList());
     }
 


### PR DESCRIPTION
## 주요 변경 사항 (Key Changes):

   * 새로운 그룹 멤버의 과거 일기 접근: 새로운 멤버가 그룹에 가입했을 때, 기존에 작성된 일기들을 복호화하여 볼 수 있도록 암호키 공유 기능을 구현했습니다.
   * E2EE 키 관리 구조 변경: 기존에는 일기(Diary)에 암호화된 AES 키가 직접 저장되었으나, 이제 각 사용자의 공개키로 암호화된 AES 키를 별도의 DiaryKey 테이블에서 관리하도록 구조를 변경했습니다. 이를 통해 각
     그룹 멤버는 자신에게 공유된 키를 사용해 일기를 복호화할 수 있습니다.

## 상세 변경 내역 (Detailed Changes):

   1. 엔티티 변경 (Entity Changes):
       * Diary 엔티티에서 encryptedAesKey 필드를 제거했습니다.
       * DiaryKey 엔티티를 새로 추가하여, 일기(FK), 사용자(FK), 그리고 해당 사용자의 공개키로 암호화된 AES 키(encryptedAesKey)를 저장합니다.

   2. API 변경 (API Changes):
       * `POST /api/groups/join-requests/{targetId}/approve`:
           * 그룹 가입 승인 시, 재암호화된 다이어리 키 목록을 요청 본문(ApproveMemberRequest)으로 받아 저장하도록 변경했습니다.
       * `GET /api/groups/join-requests/{targetId}/approval-info`:
           * 그룹 가입 승인에 필요한 정보(새로운 멤버의 공개키, 그룹 내 다이어리들의 암호화된 AES 키 목록)를 제공하는 API를 추가했습니다. 클라이언트는 이 정보를 사용하여 키를 재암호화하고 가입 승인 요청을
             보냅니다.
       * `GET /api/groups/{groupId}/members`:
           * 그룹 멤버 목록을 조회하는 API를 추가했습니다.

   3. 서비스 로직 변경 (Service Logic Changes):
       * `DiaryService`:
           * 일기 생성(createDiary): 일기 생성 시, 그룹 내 모든 멤버에 대한 DiaryKey를 함께 생성합니다.
           * 일기 상세 조회(getDiaryDetail): 현재 사용자에 해당하는 DiaryKey를 조회하여 일기 정보와 함께 반환합니다.
       * `GroupMemberService`:
           * approveMemberWithKeys: 새로운 멤버의 가입을 승인하고, 클라이언트로부터 전달받은 재암호화된 다이어리 키들을 DiaryKey 테이블에 저장합니다.
           * getApprovalInfo: 키 재암호화에 필요한 정보를 조회하는 로직을 구현했습니다.

## 기대 효과 (Expected Effects):

   * 그룹에 나중에 참여한 멤버도 이전의 모든 공유 일기를 안전하게 열람할 수 있게 되어, 공유 다이어리 서비스의 사용성이 크게 향상됩니다.
   * E2EE(종단간 암호화)를 유지하면서도 그룹 내 키 공유를 효율적으로 관리할 수 있는 기반을 마련했습니다.
